### PR TITLE
Foreign Index Constraint Support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -152,7 +152,7 @@
   branch = "master"
   name = "github.com/skeema/tengo"
   packages = ["."]
-  revision = "eeee978997419f1a9eb03f62fbd3dd858c3f9c2a"
+  revision = "7400ee21479e61c8fd69caeeb2dafdf2df497d37"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/ca.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/ca.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/ca.pem

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-cert.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-cert.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/client-cert.pem

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-key.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-key.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/client-key.pem

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-cert.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-cert.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/server-cert.pem

--- a/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-key.pem
+++ b/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-key.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/server-key.pem

--- a/vendor/github.com/docker/docker/project/CONTRIBUTING.md
+++ b/vendor/github.com/docker/docker/project/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-../CONTRIBUTING.md

--- a/vendor/github.com/skeema/tengo/Gopkg.toml
+++ b/vendor/github.com/skeema/tengo/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/fsouza/go-dockerclient"
-  version = "1.2.1"
+  version = "=1.2.1"
 
 [[constraint]]
   name = "github.com/go-sql-driver/mysql"

--- a/vendor/github.com/skeema/tengo/README.md
+++ b/vendor/github.com/skeema/tengo/README.md
@@ -12,7 +12,7 @@ Most of Go La Tengo's current functionality is focused on MySQL schema introspec
 
 ### Schema introspection
 
-Go La Tengo examines several `information_schema` tables in order to build Go struct values representing schemas (databases), tables, columns, and indexes. These values can then be diffed to generate corresponding DDL statements.
+Go La Tengo examines several `information_schema` tables in order to build Go struct values representing schemas (databases), tables, columns, indexes, and foreign key constraints. These values can then be diffed to generate corresponding DDL statements.
 
 ### Instance modeling
 
@@ -30,13 +30,11 @@ This is alpha software. The API is subject to change, and no backwards-compatibi
 
 Go La Tengo **cannot** yet diff tables containing any of the following MySQL features:
 
-* foreign keys
-* compressed tables
 * partitioned tables
 * triggers
-* non-InnoDB storage engines
 * fulltext indexes
 * spatial types
+* special features of non-InnoDB storage engines
 * generated/virtual columns (MySQL 5.7+ / Percona Server 5.7+ / MariaDB 5.2+)
 * column-level compression, with or without predefined dictionary (Percona Server 5.6.33+)
 * DEFAULT expressions (MariaDB 10.2+)
@@ -66,6 +64,7 @@ Additional [contributions](https://github.com/skeema/tengo/graphs/contributors) 
 
 * [@tomkrouper](https://github.com/tomkrouper)
 * [@efixler](https://github.com/efixler)
+* [@chrisjpalmer](https://github.com/chrisjpalmer)
 
 ## License
 

--- a/vendor/github.com/skeema/tengo/foreignkey.go
+++ b/vendor/github.com/skeema/tengo/foreignkey.go
@@ -1,0 +1,85 @@
+package tengo
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ForeignKey represents a single foreign key constraint in a table. Note that
+// the "referenced" side of the FK is tracked as strings, rather than *Schema,
+// *Table, *[]Column to avoid potentially having to introspect multiple schemas
+// in a particular order. Also, the referenced side is not gauranteed to exist,
+// especially if foreign_key_checks=0 has been used at any point in the past.
+type ForeignKey struct {
+	Name                  string
+	Columns               []*Column
+	ReferencedSchemaName  string // will be empty string if same schema
+	ReferencedTableName   string
+	ReferencedColumnNames []string // slice length always identical to len(Columns)
+	UpdateRule            string
+	DeleteRule            string
+}
+
+// Definition returns this ForeignKey's definition clause, for use as part of a DDL
+// statement.
+func (fk *ForeignKey) Definition() string {
+	colParts := make([]string, len(fk.Columns))
+	for n, col := range fk.Columns {
+		colParts[n] = EscapeIdentifier(col.Name)
+	}
+	childCols := strings.Join(colParts, ", ")
+
+	referencedTable := EscapeIdentifier(fk.ReferencedTableName)
+	if fk.ReferencedSchemaName != "" {
+		referencedTable = fmt.Sprintf("%s.%s", EscapeIdentifier(fk.ReferencedSchemaName), referencedTable)
+	}
+
+	for n, col := range fk.ReferencedColumnNames {
+		colParts[n] = EscapeIdentifier(col)
+	}
+	parentCols := strings.Join(colParts, ", ")
+
+	// MySQL does not output ON DELETE RESTRICT or ON UPDATE RESTRICT in its table create syntax.
+	// Therefore we need to omit these clauses as well if the UpdateRule or DeleteRule == "RESTRICT"
+	var deleteRule, updateRule string
+	if fk.DeleteRule != "RESTRICT" {
+		deleteRule = fmt.Sprintf(" ON DELETE %s", fk.DeleteRule)
+	}
+	if fk.UpdateRule != "RESTRICT" {
+		updateRule = fmt.Sprintf(" ON UPDATE %s", fk.UpdateRule)
+	}
+
+	return fmt.Sprintf("CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)%s%s", EscapeIdentifier(fk.Name), childCols, referencedTable, parentCols, deleteRule, updateRule)
+}
+
+// Equals returns true if two ForeignKeys are identical, false otherwise.
+func (fk *ForeignKey) Equals(other *ForeignKey) bool {
+	if fk == nil || other == nil {
+		return fk == other // only equal if BOTH are nil
+	}
+	return fk.Name == other.Name && fk.Equivalent(other)
+}
+
+// Equivalent returns true if two ForeignKeys are functionally equivalent,
+// regardless of whether or not they have the same names.
+func (fk *ForeignKey) Equivalent(other *ForeignKey) bool {
+	if fk == nil || other == nil {
+		return fk == other // only equivalent if BOTH are nil
+	}
+
+	if fk.ReferencedSchemaName != other.ReferencedSchemaName || fk.ReferencedTableName != other.ReferencedTableName {
+		return false
+	}
+	if fk.UpdateRule != other.UpdateRule || fk.DeleteRule != other.DeleteRule {
+		return false
+	}
+	if len(fk.Columns) != len(other.Columns) {
+		return false
+	}
+	for n := range fk.Columns {
+		if fk.Columns[n].Name != other.Columns[n].Name || fk.ReferencedColumnNames[n] != other.ReferencedColumnNames[n] {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/skeema/tengo/table.go
+++ b/vendor/github.com/skeema/tengo/table.go
@@ -16,6 +16,7 @@ type Table struct {
 	Columns           []*Column
 	PrimaryKey        *Index
 	SecondaryIndexes  []*Index
+	ForeignKeys       []*ForeignKey
 	Comment           string
 	NextAutoIncrement uint64
 	UnsupportedDDL    bool   // If true, tengo cannot diff this table or auto-generate its CREATE TABLE
@@ -38,7 +39,7 @@ func (t *Table) DropStatement() string {
 // is true, this means the table uses MySQL features that Tengo does not yet
 // support, and so the output of this method will differ from MySQL.
 func (t *Table) GeneratedCreateStatement() string {
-	defs := make([]string, len(t.Columns), len(t.Columns)+len(t.SecondaryIndexes)+1)
+	defs := make([]string, len(t.Columns), len(t.Columns)+len(t.SecondaryIndexes)+len(t.ForeignKeys)+1)
 	for n, c := range t.Columns {
 		defs[n] = c.Definition(t)
 	}
@@ -47,6 +48,9 @@ func (t *Table) GeneratedCreateStatement() string {
 	}
 	for _, idx := range t.SecondaryIndexes {
 		defs = append(defs, idx.Definition())
+	}
+	for _, fk := range t.ForeignKeys {
+		defs = append(defs, fk.Definition())
 	}
 	var autoIncClause string
 	if t.NextAutoIncrement > 1 {
@@ -93,6 +97,16 @@ func (t *Table) SecondaryIndexesByName() map[string]*Index {
 	result := make(map[string]*Index, len(t.SecondaryIndexes))
 	for _, idx := range t.SecondaryIndexes {
 		result[idx.Name] = idx
+	}
+	return result
+}
+
+// foreignKeysByName returns a mapping of foreign key names to ForeignKey value
+// pointers, for all foreign keys in the table.
+func (t *Table) foreignKeysByName() map[string]*ForeignKey {
+	result := make(map[string]*ForeignKey, len(t.ForeignKeys))
+	for _, fk := range t.ForeignKeys {
+		result[fk.Name] = fk
 	}
 	return result
 }
@@ -158,7 +172,6 @@ func (t *Table) Diff(to *Table) (clauses []TableAlterClause, supported bool) {
 	// explicitly state to use a different charset/collation
 	if from.CharSet != to.CharSet || from.Collation != to.Collation {
 		clauses = append(clauses, ChangeCharSet{
-			Table:     to,
 			CharSet:   to.CharSet,
 			Collation: to.Collation,
 		})
@@ -174,12 +187,12 @@ func (t *Table) Diff(to *Table) (clauses []TableAlterClause, supported bool) {
 	// Compare PK
 	if !from.PrimaryKey.Equals(to.PrimaryKey) {
 		if from.PrimaryKey == nil {
-			clauses = append(clauses, AddIndex{Table: to, Index: to.PrimaryKey})
+			clauses = append(clauses, AddIndex{Index: to.PrimaryKey})
 		} else if to.PrimaryKey == nil {
-			clauses = append(clauses, DropIndex{Table: to, Index: from.PrimaryKey})
+			clauses = append(clauses, DropIndex{Index: from.PrimaryKey})
 		} else {
-			drop := DropIndex{Table: to, Index: from.PrimaryKey}
-			add := AddIndex{Table: to, Index: to.PrimaryKey}
+			drop := DropIndex{Index: from.PrimaryKey}
+			add := AddIndex{Index: to.PrimaryKey}
 			clauses = append(clauses, drop, add)
 		}
 	}
@@ -188,43 +201,80 @@ func (t *Table) Diff(to *Table) (clauses []TableAlterClause, supported bool) {
 	// dropping and re-adding it. There's also no way to re-position an index
 	// without dropping and re-adding all preexisting indexes that now come after.
 	toIndexes := to.SecondaryIndexesByName()
+	fromIndexes := from.SecondaryIndexesByName()
 	fromIndexStillExist := make([]*Index, 0) // ordered list of indexes from "from" that still exist in "to"
 	for _, fromIdx := range from.SecondaryIndexes {
 		if _, stillExists := toIndexes[fromIdx.Name]; stillExists {
 			fromIndexStillExist = append(fromIndexStillExist, fromIdx)
 		} else {
-			clauses = append(clauses, DropIndex{Table: to, Index: fromIdx})
+			clauses = append(clauses, DropIndex{Index: fromIdx})
 		}
 	}
 	var fromCursor int
 	for _, toIdx := range to.SecondaryIndexes {
 		for fromCursor < len(fromIndexStillExist) && !fromIndexStillExist[fromCursor].Equals(toIdx) {
-			clauses = append(clauses, DropIndex{Table: to, Index: fromIndexStillExist[fromCursor]})
+			stillIdx, stillExists := toIndexes[fromIndexStillExist[fromCursor].Name]
+			clauses = append(clauses, DropIndex{
+				Index:       fromIndexStillExist[fromCursor],
+				reorderOnly: stillExists && stillIdx.Equals(fromIndexStillExist[fromCursor]),
+			})
 			fromCursor++
 		}
 		if fromCursor >= len(fromIndexStillExist) {
 			// Already went through everything in the "from" list, so all remaining "to"
 			// indexes are adds
-			clauses = append(clauses, AddIndex{Table: to, Index: toIdx})
+			prevIdx, prevExisted := fromIndexes[toIdx.Name]
+			clauses = append(clauses, AddIndex{
+				Index:       toIdx,
+				reorderOnly: prevExisted && prevIdx.Equals(toIdx),
+			})
 		} else {
 			// Current position "to" matches cursor position "from"; nothing to add or drop
 			fromCursor++
 		}
 	}
 
+	// Compare foreign keys
+	fromForeignKeys := from.foreignKeysByName()
+	toForeignKeys := to.foreignKeysByName()
+	isRename := func(fk *ForeignKey, others []*ForeignKey) bool {
+		for _, other := range others {
+			if fk.Equivalent(other) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, toFk := range toForeignKeys {
+		if _, existedBefore := fromForeignKeys[toFk.Name]; !existedBefore {
+			clauses = append(clauses, AddForeignKey{
+				ForeignKey: toFk,
+				renameOnly: isRename(toFk, from.ForeignKeys),
+			})
+		}
+	}
+	for _, fromFk := range fromForeignKeys {
+		toFk, stillExists := toForeignKeys[fromFk.Name]
+		if !stillExists {
+			clauses = append(clauses, DropForeignKey{
+				ForeignKey: fromFk,
+				renameOnly: isRename(fromFk, to.ForeignKeys),
+			})
+		} else if !fromFk.Equals(toFk) {
+			drop := DropForeignKey{ForeignKey: fromFk}
+			add := AddForeignKey{ForeignKey: toFk}
+			clauses = append(clauses, drop, add)
+		}
+	}
+
 	// Compare storage engine
 	if from.Engine != to.Engine {
-		cse := ChangeStorageEngine{
-			Table:            to,
-			NewStorageEngine: to.Engine,
-		}
-		clauses = append(clauses, cse)
+		clauses = append(clauses, ChangeStorageEngine{NewStorageEngine: to.Engine})
 	}
 
 	// Compare next auto-inc value
 	if from.NextAutoIncrement != to.NextAutoIncrement && to.HasAutoIncrement() {
 		cai := ChangeAutoIncrement{
-			Table:                to,
 			NewNextAutoIncrement: to.NextAutoIncrement,
 			OldNextAutoIncrement: from.NextAutoIncrement,
 		}
@@ -234,7 +284,6 @@ func (t *Table) Diff(to *Table) (clauses []TableAlterClause, supported bool) {
 	// Compare create options
 	if from.CreateOptions != to.CreateOptions {
 		cco := ChangeCreateOptions{
-			Table:            to,
 			OldCreateOptions: from.CreateOptions,
 			NewCreateOptions: to.CreateOptions,
 		}
@@ -243,11 +292,7 @@ func (t *Table) Diff(to *Table) (clauses []TableAlterClause, supported bool) {
 
 	// Compare comment
 	if from.Comment != to.Comment {
-		cc := ChangeComment{
-			Table:      to,
-			NewComment: to.Comment,
-		}
-		clauses = append(clauses, cc)
+		clauses = append(clauses, ChangeComment{NewComment: to.Comment})
 	}
 
 	// If the SHOW CREATE TABLE output differed between the two tables, but we
@@ -318,7 +363,6 @@ func (cc *columnsComparison) columnDrops() []TableAlterClause {
 	for fromPos, stillPresent := range cc.fromStillPresent {
 		if !stillPresent {
 			clauses = append(clauses, DropColumn{
-				Table:  cc.fromTable,
 				Column: cc.fromTable.Columns[fromPos],
 			})
 		}


### PR DESCRIPTION
This commit supports foreign indexes so that foreign indexes can be added and dropped from tables. Since neither operation is destructive the `AddConstraint` and `DropConstraint` structs return false when their `Unsafe()` method is called. 

The only thing to be aware of is, adding a foreign constraint to an existing column with data will NOT produce an error if any of the data does not match the referenced table. This is because (I assume) foreign key checks are temporarily disabled.

Evan I would be interested in your feedback on this change and whether you think my simple implementation will work in most use cases OR if there should be additional systems in place to safely facilitate foreign key constraints.