### PR TITLE
Add ignore-*-regex options for table and schema

### DIFF
--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -24,8 +24,8 @@ An exit code of 0 will be returned if no differences were found, 1 if some
 differences were found, or 2+ if an error occurred.`
 
 	cmd := mybase.NewCommand("diff", summary, desc, DiffHandler)
-	cmd.AddOption(mybase.StringOption("ignore-schema-regex", 0, "", "Ignore schemas that match regex"))
-	cmd.AddOption(mybase.StringOption("ignore-table-regex", 0, "", "Ignore tables that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-schema", 0, "", "Ignore schemas that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-table", 0, "", "Ignore tables that match regex"))
 	cmd.AddArg("environment", "production", false)
 	CommandSuite.AddSubCommand(cmd)
 	clonePushOptionsToDiff()

--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -24,6 +24,8 @@ An exit code of 0 will be returned if no differences were found, 1 if some
 differences were found, or 2+ if an error occurred.`
 
 	cmd := mybase.NewCommand("diff", summary, desc, DiffHandler)
+	cmd.AddOption(mybase.StringOption("ignore-schema-regex", 0, "", "Ignore schemas that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-table-regex", 0, "", "Ignore tables that match regex"))
 	cmd.AddArg("environment", "production", false)
 	CommandSuite.AddSubCommand(cmd)
 	clonePushOptionsToDiff()

--- a/cmd_init.go
+++ b/cmd_init.go
@@ -180,13 +180,13 @@ func PopulateSchemaDir(s *tengo.Schema, parentDir *Dir, makeSubdir bool) error {
 	if s.Name == parentDir.Config.Get("temp-schema") {
 		return nil
 	}
-	ignoreSchemaRegex := parentDir.Config.Get("ignore-schema")
-	schemaRE, sErr := regexp.Compile(ignoreSchemaRegex)
+	ignoreSchema := parentDir.Config.Get("ignore-schema")
+	schemaRE, sErr := regexp.Compile(ignoreSchema)
 	if sErr != nil {
-		return fmt.Errorf("Invalid regular expression on ignore-schema: %s; %s", ignoreSchemaRegex, sErr)
+		return fmt.Errorf("Invalid regular expression on ignore-schema: %s; %s", ignoreSchema, sErr)
 	}
-	if ignoreSchemaRegex != "" && schemaRE.MatchString(s.Name) {
-		log.Warnf("Skipping schema %s because of ignore-schema='%s'", s.Name, ignoreSchemaRegex)
+	if ignoreSchema != "" && schemaRE.MatchString(s.Name) {
+		log.Warnf("Skipping schema %s because of ignore-schema='%s'", s.Name, ignoreSchema)
 		return nil
 	}
 
@@ -223,14 +223,14 @@ func PopulateSchemaDir(s *tengo.Schema, parentDir *Dir, makeSubdir bool) error {
 	if err != nil {
 		return fmt.Errorf("Cannot obtain table information for %s: %s", s.Name, err)
 	}
-	ignoreTableRegex := parentDir.Config.Get("ignore-table")
-	re, err := regexp.Compile(ignoreTableRegex)
+	ignoreTable := parentDir.Config.Get("ignore-table")
+	re, err := regexp.Compile(ignoreTable)
 	if err != nil {
-		return fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err)
+		return fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTable, err)
 	}
 	for _, t := range tables {
-		if ignoreTableRegex != "" && re.MatchString(t.Name) {
-			log.Warnf("Skipping table %s because ignore-table matched %s", t.Name, ignoreTableRegex)
+		if ignoreTable != "" && re.MatchString(t.Name) {
+			log.Warnf("Skipping table %s because ignore-table matched %s", t.Name, ignoreTable)
 			continue
 		}
 		createStmt := t.CreateStatement()

--- a/cmd_init.go
+++ b/cmd_init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -34,6 +35,8 @@ section of the file.`
 	cmd.AddOption(mybase.StringOption("dir", 'd', "<hostname>", "Base dir to use for this host's schemas"))
 	cmd.AddOption(mybase.StringOption("schema", 0, "", "Only import the one specified schema; skip creation of subdirs for each schema"))
 	cmd.AddOption(mybase.BoolOption("include-auto-inc", 0, false, "Include starting auto-inc values in table files"))
+	cmd.AddOption(mybase.StringOption("ignore-schema-regex", 0, "", "Ignore schemas that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-table-regex", 0, "", "Ignore tables that match regex"))
 	cmd.AddArg("environment", "production", false)
 	CommandSuite.AddSubCommand(cmd)
 }
@@ -121,6 +124,12 @@ func InitHandler(cfg *mybase.Config) error {
 	if cfg.OnCLI("user") {
 		hostOptionFile.SetOptionValue(environment, "user", cfg.Get("user"))
 	}
+	if cfg.OnCLI("ignore-schema-regex") {
+		hostOptionFile.SetOptionValue(environment, "ignore-schema-regex", cfg.Get("ignore-schema-regex"))
+	}
+	if cfg.OnCLI("ignore-table-regex") {
+		hostOptionFile.SetOptionValue(environment, "ignore-table-regex", cfg.Get("ignore-table-regex"))
+	}
 	if !separateSchemaSubdir {
 		// schema name is placed outside of any named section/environment since the
 		// default assumption is that schema names match between environments
@@ -171,6 +180,15 @@ func PopulateSchemaDir(s *tengo.Schema, parentDir *Dir, makeSubdir bool) error {
 	if s.Name == parentDir.Config.Get("temp-schema") {
 		return nil
 	}
+	ignoreSchemaRegex := parentDir.Config.Get("ignore-schema-regex")
+	schemaRE, sErr := regexp.Compile(ignoreSchemaRegex)
+	if sErr != nil {
+		return fmt.Errorf("Invalid regular expression on ignore-schema-regex: %s; %s", ignoreSchemaRegex, sErr)
+	}
+	if ignoreSchemaRegex != "" && schemaRE.MatchString(s.Name) {
+		log.Debugf("Skipping schema %s because of ignore-schema-regex='%s'", s.Name, ignoreSchemaRegex)
+		return nil
+	}
 
 	var schemaDir *Dir
 	var err error
@@ -205,7 +223,16 @@ func PopulateSchemaDir(s *tengo.Schema, parentDir *Dir, makeSubdir bool) error {
 	if err != nil {
 		return fmt.Errorf("Cannot obtain table information for %s: %s", s.Name, err)
 	}
+	ignoreTableRegex := parentDir.Config.Get("ignore-table-regex")
+	re, err := regexp.Compile(ignoreTableRegex)
+	if err != nil {
+		return fmt.Errorf("Invalid regular expression on ignore-table-regex: %s; %s", ignoreTableRegex, err)
+	}
 	for _, t := range tables {
+		if ignoreTableRegex != "" && re.MatchString(t.Name) {
+			log.Debugf("Skipping table %s because ignore-table-regex matched %s", t.Name, ignoreTableRegex)
+			continue
+		}
 		createStmt := t.CreateStatement()
 
 		// Special handling for auto-increment tables: strip next-auto-inc value,

--- a/cmd_init.go
+++ b/cmd_init.go
@@ -35,8 +35,8 @@ section of the file.`
 	cmd.AddOption(mybase.StringOption("dir", 'd', "<hostname>", "Base dir to use for this host's schemas"))
 	cmd.AddOption(mybase.StringOption("schema", 0, "", "Only import the one specified schema; skip creation of subdirs for each schema"))
 	cmd.AddOption(mybase.BoolOption("include-auto-inc", 0, false, "Include starting auto-inc values in table files"))
-	cmd.AddOption(mybase.StringOption("ignore-schema-regex", 0, "", "Ignore schemas that match regex"))
-	cmd.AddOption(mybase.StringOption("ignore-table-regex", 0, "", "Ignore tables that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-schema", 0, "", "Ignore schemas that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-table", 0, "", "Ignore tables that match regex"))
 	cmd.AddArg("environment", "production", false)
 	CommandSuite.AddSubCommand(cmd)
 }
@@ -124,11 +124,11 @@ func InitHandler(cfg *mybase.Config) error {
 	if cfg.OnCLI("user") {
 		hostOptionFile.SetOptionValue(environment, "user", cfg.Get("user"))
 	}
-	if cfg.OnCLI("ignore-schema-regex") {
-		hostOptionFile.SetOptionValue(environment, "ignore-schema-regex", cfg.Get("ignore-schema-regex"))
+	if cfg.OnCLI("ignore-schema") {
+		hostOptionFile.SetOptionValue(environment, "ignore-schema", cfg.Get("ignore-schema"))
 	}
-	if cfg.OnCLI("ignore-table-regex") {
-		hostOptionFile.SetOptionValue(environment, "ignore-table-regex", cfg.Get("ignore-table-regex"))
+	if cfg.OnCLI("ignore-table") {
+		hostOptionFile.SetOptionValue(environment, "ignore-table", cfg.Get("ignore-table"))
 	}
 	if !separateSchemaSubdir {
 		// schema name is placed outside of any named section/environment since the
@@ -180,13 +180,13 @@ func PopulateSchemaDir(s *tengo.Schema, parentDir *Dir, makeSubdir bool) error {
 	if s.Name == parentDir.Config.Get("temp-schema") {
 		return nil
 	}
-	ignoreSchemaRegex := parentDir.Config.Get("ignore-schema-regex")
+	ignoreSchemaRegex := parentDir.Config.Get("ignore-schema")
 	schemaRE, sErr := regexp.Compile(ignoreSchemaRegex)
 	if sErr != nil {
-		return fmt.Errorf("Invalid regular expression on ignore-schema-regex: %s; %s", ignoreSchemaRegex, sErr)
+		return fmt.Errorf("Invalid regular expression on ignore-schema: %s; %s", ignoreSchemaRegex, sErr)
 	}
 	if ignoreSchemaRegex != "" && schemaRE.MatchString(s.Name) {
-		log.Debugf("Skipping schema %s because of ignore-schema-regex='%s'", s.Name, ignoreSchemaRegex)
+		log.Debugf("Skipping schema %s because of ignore-schema='%s'", s.Name, ignoreSchemaRegex)
 		return nil
 	}
 
@@ -223,14 +223,14 @@ func PopulateSchemaDir(s *tengo.Schema, parentDir *Dir, makeSubdir bool) error {
 	if err != nil {
 		return fmt.Errorf("Cannot obtain table information for %s: %s", s.Name, err)
 	}
-	ignoreTableRegex := parentDir.Config.Get("ignore-table-regex")
+	ignoreTableRegex := parentDir.Config.Get("ignore-table")
 	re, err := regexp.Compile(ignoreTableRegex)
 	if err != nil {
-		return fmt.Errorf("Invalid regular expression on ignore-table-regex: %s; %s", ignoreTableRegex, err)
+		return fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err)
 	}
 	for _, t := range tables {
 		if ignoreTableRegex != "" && re.MatchString(t.Name) {
-			log.Debugf("Skipping table %s because ignore-table-regex matched %s", t.Name, ignoreTableRegex)
+			log.Debugf("Skipping table %s because ignore-table matched %s", t.Name, ignoreTableRegex)
 			continue
 		}
 		createStmt := t.CreateStatement()

--- a/cmd_init.go
+++ b/cmd_init.go
@@ -186,7 +186,7 @@ func PopulateSchemaDir(s *tengo.Schema, parentDir *Dir, makeSubdir bool) error {
 		return fmt.Errorf("Invalid regular expression on ignore-schema: %s; %s", ignoreSchemaRegex, sErr)
 	}
 	if ignoreSchemaRegex != "" && schemaRE.MatchString(s.Name) {
-		log.Debugf("Skipping schema %s because of ignore-schema='%s'", s.Name, ignoreSchemaRegex)
+		log.Warnf("Skipping schema %s because of ignore-schema='%s'", s.Name, ignoreSchemaRegex)
 		return nil
 	}
 
@@ -230,7 +230,7 @@ func PopulateSchemaDir(s *tengo.Schema, parentDir *Dir, makeSubdir bool) error {
 	}
 	for _, t := range tables {
 		if ignoreTableRegex != "" && re.MatchString(t.Name) {
-			log.Debugf("Skipping table %s because ignore-table matched %s", t.Name, ignoreTableRegex)
+			log.Warnf("Skipping table %s because ignore-table matched %s", t.Name, ignoreTableRegex)
 			continue
 		}
 		createStmt := t.CreateStatement()

--- a/cmd_lint.go
+++ b/cmd_lint.go
@@ -51,6 +51,17 @@ func LintHandler(cfg *mybase.Config) error {
 			continue
 		}
 
+		ignoreSchema := t.Dir.Config.Get("ignore-schema")
+		re, sErr := regexp.Compile(ignoreSchema)
+		if sErr != nil {
+			return fmt.Errorf("Invalid regular expression on ignore-schema: %s; %s", ignoreSchema, sErr)
+		}
+		dir := fmt.Sprintf("%s", t.Dir)
+		if ignoreSchema != "" && re.MatchString(dir) {
+			log.Warnf("Skipping schema %s because of ignore-schema='%s'", dir, ignoreSchema)
+			continue
+		}
+
 		log.Infof("Linting %s", t.Dir)
 
 		for _, sf := range t.SQLFileErrors {

--- a/cmd_lint.go
+++ b/cmd_lint.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"regexp"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/skeema/mybase"
@@ -21,7 +22,7 @@ You may optionally pass an environment name as a CLI option. This will affect
 which section of .skeema config files is used for obtaining a database instance
 to test the SQL DDL against. For example, running ` + "`" + `skeema lint staging` + "`" + ` will
 apply config directives from the [staging] section of config files, as well as
-any sectionless directives at the top of the file. If no environment name is 
+any sectionless directives at the top of the file. If no environment name is
 supplied, the default is "production".
 
 An exit code of 0 will be returned if all files were already formatted properly,
@@ -57,8 +58,17 @@ func LintHandler(cfg *mybase.Config) error {
 			sqlErrCount++
 		}
 
+		ignoreTable := t.Dir.Config.Get("ignore-table")
+		re, err := regexp.Compile(ignoreTable)
+		if err != nil {
+			return fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTable, err)
+		}
 		tables, _ := t.SchemaFromDir.Tables() // can ignore error since table list already guaranteed to be cached
 		for _, table := range tables {
+			if ignoreTable != "" && re.MatchString(table.Name) {
+				log.Warnf("Skipping table %s because ignore-table matched %s", table.Name, ignoreTable)
+				continue
+			}
 			sf := SQLFile{
 				Dir:      t.Dir,
 				FileName: fmt.Sprintf("%s.sql", table.Name),

--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -111,10 +111,10 @@ func PullHandler(cfg *mybase.Config) error {
 		} else {
 			mods.NextAutoInc = tengo.NextAutoIncIfAlready
 		}
-		ignoreTableRegex := t.Dir.Config.Get("ignore-table")
-		re, err := regexp.Compile(ignoreTableRegex)
+		ignoreTable := t.Dir.Config.Get("ignore-table")
+		re, err := regexp.Compile(ignoreTable)
 		if err != nil {
-			return fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err)
+			return fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTable, err)
 		}
 		for _, td := range diff.TableDiffs {
 			tableName := ""
@@ -128,8 +128,8 @@ func PullHandler(cfg *mybase.Config) error {
 			default:
 				return fmt.Errorf("Unsupported diff type %T", td)
 			}
-			if ignoreTableRegex != "" && re.MatchString(tableName) {
-				log.Warnf("Skipping table %s because ignore-table matched %s", tableName, ignoreTableRegex)
+			if ignoreTable != "" && re.MatchString(tableName) {
+				log.Warnf("Skipping table %s because ignore-table matched %s", tableName, ignoreTable)
 				continue
 			}
 			stmt, err := td.Statement(mods)

--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -114,7 +114,7 @@ func PullHandler(cfg *mybase.Config) error {
 		ignoreTableRegex := t.Dir.Config.Get("ignore-table")
 		re, err := regexp.Compile(ignoreTableRegex)
 		if err != nil {
-			return fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err)
+			return fmt.Warnf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err)
 		}
 		for _, td := range diff.TableDiffs {
 			tableName := ""
@@ -129,7 +129,7 @@ func PullHandler(cfg *mybase.Config) error {
 				return fmt.Errorf("Unsupported diff type %T", td)
 			}
 			if ignoreTableRegex != "" && re.MatchString(tableName) {
-				log.Debugf("Skipping table %s because ignore-table matched %s", tableName, ignoreTableRegex)
+				log.Warnf("Skipping table %s because ignore-table matched %s", tableName, ignoreTableRegex)
 				continue
 			}
 			stmt, err := td.Statement(mods)

--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -27,8 +27,8 @@ top of the file. If no environment name is supplied, the default is
 	cmd := mybase.NewCommand("pull", summary, desc, PullHandler)
 	cmd.AddOption(mybase.BoolOption("include-auto-inc", 0, false, "Include starting auto-inc values in new table files, and update in existing files"))
 	cmd.AddOption(mybase.BoolOption("normalize", 0, true, "Reformat *.sql files to match SHOW CREATE TABLE"))
-	cmd.AddOption(mybase.StringOption("ignore-schema-regex", 0, "", "Ignore schemas that match regex"))
-	cmd.AddOption(mybase.StringOption("ignore-table-regex", 0, "", "Ignore tables that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-schema", 0, "", "Ignore schemas that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-table", 0, "", "Ignore tables that match regex"))
 	cmd.AddArg("environment", "production", false)
 	CommandSuite.AddSubCommand(cmd)
 }
@@ -111,10 +111,10 @@ func PullHandler(cfg *mybase.Config) error {
 		} else {
 			mods.NextAutoInc = tengo.NextAutoIncIfAlready
 		}
-		ignoreTableRegex := t.Dir.Config.Get("ignore-table-regex")
+		ignoreTableRegex := t.Dir.Config.Get("ignore-table")
 		re, err := regexp.Compile(ignoreTableRegex)
 		if err != nil {
-			return fmt.Errorf("Invalid regular expression on ignore-table-regex: %s; %s", ignoreTableRegex, err)
+			return fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err)
 		}
 		for _, td := range diff.TableDiffs {
 			tableName := ""
@@ -129,7 +129,7 @@ func PullHandler(cfg *mybase.Config) error {
 				return fmt.Errorf("Unsupported diff type %T", td)
 			}
 			if ignoreTableRegex != "" && re.MatchString(tableName) {
-				log.Debugf("Skipping table %s because ignore-table-regex matched %s", tableName, ignoreTableRegex)
+				log.Debugf("Skipping table %s because ignore-table matched %s", tableName, ignoreTableRegex)
 				continue
 			}
 			stmt, err := td.Statement(mods)

--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -114,7 +114,7 @@ func PullHandler(cfg *mybase.Config) error {
 		ignoreTableRegex := t.Dir.Config.Get("ignore-table")
 		re, err := regexp.Compile(ignoreTableRegex)
 		if err != nil {
-			return fmt.Warnf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err)
+			return fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err)
 		}
 		for _, td := range diff.TableDiffs {
 			tableName := ""

--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -116,7 +116,6 @@ func PullHandler(cfg *mybase.Config) error {
 		if err != nil {
 			return fmt.Errorf("Invalid regular expression on ignore-table-regex: %s; %s", ignoreTableRegex, err)
 		}
-		// ignoreTableRegex := t.Dir.Config.Get("ignore-table-regex")
 		for _, td := range diff.TableDiffs {
 			tableName := ""
 			switch td := td.(type) {

--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -137,21 +137,6 @@ func PullHandler(cfg *mybase.Config) error {
 			if err != nil {
 				return err
 			}
-			tableName := ""
-			switch td := td.(type) {
-			case tengo.CreateTable:
-				tableName = td.Table.Name
-			case tengo.DropTable:
-				tableName = td.Table.Name
-			case tengo.AlterTable:
-				tableName = td.Table.Name
-			default:
-				return fmt.Errorf("Unsupported diff type %T", td)
-			}
-			stmt, err := td.Statement(mods)
-			if err != nil {
-				return err
-			}
 			switch td := td.(type) {
 			case tengo.CreateTable:
 				sf := SQLFile{

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -233,7 +233,7 @@ func pushWorker(sps *sharedPushState) {
 					return
 				}
 				if ignoreTableRegex != "" && re.MatchString(tableName) {
-					log.Debugf("Skipping table %s because ignore-table matched %s", tableName, ignoreTableRegex)
+					log.Warnf("Skipping table %s because ignore-table matched %s", tableName, ignoreTableRegex)
 					continue
 				}
 				targetStmtCount++

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -208,10 +208,10 @@ func pushWorker(sps *sharedPushState) {
 				sps.setFatalError(err)
 				return
 			}
-			ignoreTableRegex := t.Dir.Config.Get("ignore-table")
-			re, err := regexp.Compile(ignoreTableRegex)
+			ignoreTable := t.Dir.Config.Get("ignore-table")
+			re, err := regexp.Compile(ignoreTable)
 			if err != nil {
-				sps.setFatalError(fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err))
+				sps.setFatalError(fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTable, err))
 				return
 			}
 			for n, tableDiff := range diff.TableDiffs {
@@ -232,8 +232,8 @@ func pushWorker(sps *sharedPushState) {
 					sps.setFatalError(fmt.Errorf("Unsupported diff type %T", td))
 					return
 				}
-				if ignoreTableRegex != "" && re.MatchString(tableName) {
-					log.Warnf("Skipping table %s because ignore-table matched %s", tableName, ignoreTableRegex)
+				if ignoreTable != "" && re.MatchString(tableName) {
+					log.Warnf("Skipping table %s because ignore-table matched %s", tableName, ignoreTable)
 					continue
 				}
 				targetStmtCount++

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -38,8 +38,8 @@ top of the file. If no environment name is supplied, the default is
 	cmd.AddOption(mybase.StringOption("ddl-wrapper", 'X', "", "Like --alter-wrapper, but applies to all DDL types (CREATE, DROP, ALTER)"))
 	cmd.AddOption(mybase.StringOption("safe-below-size", 0, "0", "Always permit destructive operations for tables below this size in bytes"))
 	cmd.AddOption(mybase.StringOption("concurrent-instances", 'c', "1", "Perform operations on this number of instances concurrently"))
-	cmd.AddOption(mybase.StringOption("ignore-schema-regex", 0, "", "Ignore schemas that match regex"))
-	cmd.AddOption(mybase.StringOption("ignore-table-regex", 0, "", "Ignore tables that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-schema", 0, "", "Ignore schemas that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-table", 0, "", "Ignore tables that match regex"))
 	cmd.AddArg("environment", "production", false)
 	CommandSuite.AddSubCommand(cmd)
 	clonePushOptionsToDiff()
@@ -208,10 +208,10 @@ func pushWorker(sps *sharedPushState) {
 				sps.setFatalError(err)
 				return
 			}
-			ignoreTableRegex := t.Dir.Config.Get("ignore-table-regex")
+			ignoreTableRegex := t.Dir.Config.Get("ignore-table")
 			re, err := regexp.Compile(ignoreTableRegex)
 			if err != nil {
-				sps.setFatalError(fmt.Errorf("Invalid regular expression on ignore-table-regex: %s; %s", ignoreTableRegex, err))
+				sps.setFatalError(fmt.Errorf("Invalid regular expression on ignore-table: %s; %s", ignoreTableRegex, err))
 				return
 			}
 			for n, tableDiff := range diff.TableDiffs {
@@ -233,7 +233,7 @@ func pushWorker(sps *sharedPushState) {
 					return
 				}
 				if ignoreTableRegex != "" && re.MatchString(tableName) {
-					log.Debugf("Skipping table %s because ignore-table-regex matched %s", tableName, ignoreTableRegex)
+					log.Debugf("Skipping table %s because ignore-table matched %s", tableName, ignoreTableRegex)
 					continue
 				}
 				targetStmtCount++

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -37,6 +38,8 @@ top of the file. If no environment name is supplied, the default is
 	cmd.AddOption(mybase.StringOption("ddl-wrapper", 'X', "", "Like --alter-wrapper, but applies to all DDL types (CREATE, DROP, ALTER)"))
 	cmd.AddOption(mybase.StringOption("safe-below-size", 0, "0", "Always permit destructive operations for tables below this size in bytes"))
 	cmd.AddOption(mybase.StringOption("concurrent-instances", 'c', "1", "Perform operations on this number of instances concurrently"))
+	cmd.AddOption(mybase.StringOption("ignore-schema-regex", 0, "", "Ignore schemas that match regex"))
+	cmd.AddOption(mybase.StringOption("ignore-table-regex", 0, "", "Ignore tables that match regex"))
 	cmd.AddArg("environment", "production", false)
 	CommandSuite.AddSubCommand(cmd)
 	clonePushOptionsToDiff()
@@ -205,11 +208,32 @@ func pushWorker(sps *sharedPushState) {
 				sps.setFatalError(err)
 				return
 			}
-
+			ignoreTableRegex := t.Dir.Config.Get("ignore-table-regex")
+			re, err := regexp.Compile(ignoreTableRegex)
+			if err != nil {
+				sps.setFatalError(fmt.Errorf("Invalid regular expression on ignore-table-regex: %s; %s", ignoreTableRegex, err))
+				return
+			}
 			for n, tableDiff := range diff.TableDiffs {
 				ddl := NewDDLStatement(tableDiff, mods, t)
 				if ddl == nil {
 					// skip blank DDL (which may happen due to NextAutoInc modifier)
+					continue
+				}
+				tableName := ""
+				switch td := tableDiff.(type) {
+				case tengo.CreateTable:
+					tableName = td.Table.Name
+				case tengo.DropTable:
+					tableName = td.Table.Name
+				case tengo.AlterTable:
+					tableName = td.Table.Name
+				default:
+					sps.setFatalError(fmt.Errorf("Unsupported diff type %T", td))
+					return
+				}
+				if ignoreTableRegex != "" && re.MatchString(tableName) {
+					log.Debugf("Skipping table %s because ignore-table-regex matched %s", tableName, ignoreTableRegex)
 					continue
 				}
 				targetStmtCount++

--- a/configutils.go
+++ b/configutils.go
@@ -26,8 +26,8 @@ func AddGlobalOptions(cmd *mybase.Command) {
 	cmd.AddOption(mybase.StringOption("port", 0, "3306", "Port to use for database host").Hidden())
 	cmd.AddOption(mybase.StringOption("socket", 'S', "/tmp/mysql.sock", "Absolute path to Unix socket file used if host is localhost").Hidden())
 	cmd.AddOption(mybase.StringOption("schema", 0, "", "Database schema name").Hidden())
-	cmd.AddOption(mybase.StringOption("ignore-schema-regex", 0, "", "Ignore schemas that match regex").Hidden())
-	cmd.AddOption(mybase.StringOption("ignore-table-regex", 0, "", "Ignore tables that match regex").Hidden())
+	cmd.AddOption(mybase.StringOption("ignore-schema", 0, "", "Ignore schemas that match regex").Hidden())
+	cmd.AddOption(mybase.StringOption("ignore-table", 0, "", "Ignore tables that match regex").Hidden())
 	cmd.AddOption(mybase.StringOption("default-character-set", 0, "", "Schema-level default character set").Hidden())
 	cmd.AddOption(mybase.StringOption("default-collation", 0, "", "Schema-level default collation").Hidden())
 

--- a/configutils.go
+++ b/configutils.go
@@ -26,6 +26,8 @@ func AddGlobalOptions(cmd *mybase.Command) {
 	cmd.AddOption(mybase.StringOption("port", 0, "3306", "Port to use for database host").Hidden())
 	cmd.AddOption(mybase.StringOption("socket", 'S', "/tmp/mysql.sock", "Absolute path to Unix socket file used if host is localhost").Hidden())
 	cmd.AddOption(mybase.StringOption("schema", 0, "", "Database schema name").Hidden())
+	cmd.AddOption(mybase.StringOption("ignore-schema-regex", 0, "", "Ignore schemas that match regex").Hidden())
+	cmd.AddOption(mybase.StringOption("ignore-table-regex", 0, "", "Ignore tables that match regex").Hidden())
 	cmd.AddOption(mybase.StringOption("default-character-set", 0, "", "Schema-level default character set").Hidden())
 	cmd.AddOption(mybase.StringOption("default-collation", 0, "", "Schema-level default collation").Hidden())
 

--- a/doc/options.md
+++ b/doc/options.md
@@ -19,6 +19,8 @@
 * [first-only](#first-only)
 * [host](#host)
 * [host-wrapper](#host-wrapper)
+* [ignore-schema-regex](#ignore-schema-regex)
+* [ignore-table-regex](#ignore-table-regex)
 * [include-auto-inc](#include-auto-inc)
 * [normalize](#normalize)
 * [password](#password)
@@ -249,7 +251,7 @@ Commands | *all*
 
 This option specifies the default character set to use for a particular schema. Its name and purpose matches the corresponding option in MySQL `db.opt` files. In Skeema, this option is only needed in cases where some schemas have a different default character set than the server-level default.
 
-When `skeema init` or `skeema pull` imports a schema subdirectory for the first time, or when `skeema pull` updates an existing schema subdirectory, the schema's default character set will be compared to the instance's server-level default character set. If they differ, [default-character-set](#default-character-set) will be populated in the subdir's .skeema file automatically. Otherwise, it will be omitted. 
+When `skeema init` or `skeema pull` imports a schema subdirectory for the first time, or when `skeema pull` updates an existing schema subdirectory, the schema's default character set will be compared to the instance's server-level default character set. If they differ, [default-character-set](#default-character-set) will be populated in the subdir's .skeema file automatically. Otherwise, it will be omitted.
 
 If a new schema is being created for the first time via `skeema push`, and [default-character-set](#default-character-set) has been set, it will be included as part of the `CREATE DATABASE` statement. If it has not been set, the instance's default server-level character set is used instead.
 
@@ -265,7 +267,7 @@ Commands | *all*
 
 This option specifies the default collation to use for a particular schema. Its name and purpose matches the corresponding option in MySQL `db.opt` files. In Skeema, this option is only needed in cases where some schemas have a different default collation than the server-level default.
 
-When `skeema init` or `skeema pull` imports a schema subdirectory for the first time, or when `skeema pull` updates an existing schema subdirectory, the schema's default collation will be compared to the instance's server-level default collation. If they differ, [default-collation](#default-collation) will be populated in the subdir's .skeema file automatically. Otherwise, it will be omitted. 
+When `skeema init` or `skeema pull` imports a schema subdirectory for the first time, or when `skeema pull` updates an existing schema subdirectory, the schema's default collation will be compared to the instance's server-level default collation. If they differ, [default-collation](#default-collation) will be populated in the subdir's .skeema file automatically. Otherwise, it will be omitted.
 
 If a new schema is being created for the first time via `skeema push`, and [default-collation](#default-collation) has been set, it will be included as part of the `CREATE DATABASE` statement. If it has not been set, the instance's default server-level collation is used instead.
 
@@ -331,7 +333,7 @@ Commands | *all*
 **Type** | string
 **Restrictions** | none
 
-This option controls how the [host](#host) option is interpreted, and can be used to allow Skeema to interface with service discovery systems. 
+This option controls how the [host](#host) option is interpreted, and can be used to allow Skeema to interface with service discovery systems.
 
 By default, [host-wrapper](#host-wrapper) is blank, and [host](#host) values are interpreted literally as domain names or addresses (no service discovery). To configure Skeema to use service discovery instead, set [host-wrapper](#host-wrapper) to an external command-line to execute. Then, whenever Skeema needs to perform an operation on one or more database instances, it will execute the external command to determine which instances to operate on, instead of using [host](#host) as a literal value.
 
@@ -358,6 +360,24 @@ If ports are omitted, the [port](#port) option is used instead, which defaults t
 
 The external command should only return addresses of master instances, never replicas.
 
+### ignore-schema-regex
+Commands | init
+--- | :---
+**Default** | *empty string*
+**Type** | String
+**Restrictions** | valid regex
+
+Normally skeema will run iterating through every not system schema. This option will allow you to ignore schemas that you do not want to be used with skeema.
+
+### ignore-table-regex
+Commands | init
+--- | :---
+**Default** | *empty string*
+**Type** | String
+**Restrictions** | valid regex
+
+Many tools like gh-ost and pt-online-schema-change will create temporary tables that you will not want to have as part of your skeema workflow. When initializing skeema you can run `skeema init --ignore-table-regex="^_.*" ...` to setup your cluster to not look at these temporary files. Any valid regex can be used.
+
 ### include-auto-inc
 
 Commands | init, pull
@@ -376,7 +396,7 @@ Only set this to true if you intentionally need to track auto_increment values i
 
 ### normalize
 
-Commands | pull 
+Commands | pull
 --- | :---
 **Default** | true
 **Type** | boolean
@@ -502,7 +522,7 @@ Commands | *all*
 **Type** | string
 **Restrictions** | none
 
-Specifies the name of the MySQL user to connect with. 
+Specifies the name of the MySQL user to connect with.
 
 ### verify
 
@@ -515,4 +535,3 @@ Commands | diff, push
 Controls whether generated `ALTER TABLE` statements are automatically verified for correctness. If true, each generated ALTER will be tested in the temporary schema. See [the FAQ](faq.md#auto-generated-ddl-is-verified-for-correctness) for more information.
 
 It is recommended that this variable be left at its default of true, but if desired you can disable verification for speed reasons.
-

--- a/doc/options.md
+++ b/doc/options.md
@@ -19,8 +19,8 @@
 * [first-only](#first-only)
 * [host](#host)
 * [host-wrapper](#host-wrapper)
-* [ignore-schema-regex](#ignore-schema-regex)
-* [ignore-table-regex](#ignore-table-regex)
+* [ignore-schema](#ignore-schema)
+* [ignore-table](#ignore-table)
 * [include-auto-inc](#include-auto-inc)
 * [normalize](#normalize)
 * [password](#password)
@@ -360,7 +360,7 @@ If ports are omitted, the [port](#port) option is used instead, which defaults t
 
 The external command should only return addresses of master instances, never replicas.
 
-### ignore-schema-regex
+### ignore-schema
 Commands | init
 --- | :---
 **Default** | *empty string*
@@ -369,14 +369,14 @@ Commands | init
 
 Normally skeema will run iterating through every not system schema. This option will allow you to ignore schemas that you do not want to be used with skeema.
 
-### ignore-table-regex
+### ignore-table
 Commands | init
 --- | :---
 **Default** | *empty string*
 **Type** | String
 **Restrictions** | valid regex
 
-Many tools like gh-ost and pt-online-schema-change will create temporary tables that you will not want to have as part of your skeema workflow. When initializing skeema you can run `skeema init --ignore-table-regex="^_.*" ...` to setup your cluster to not look at these temporary files. Any valid regex can be used.
+Many tools like gh-ost and pt-online-schema-change will create temporary tables that you will not want to have as part of your skeema workflow. When initializing skeema you can run `skeema init --ignore-table="^_.*" ...` to setup your cluster to not look at these temporary files. Any valid regex can be used.
 
 ### include-auto-inc
 


### PR DESCRIPTION
This change will allow users to ignore certain tables or schemas while
using skeema. The main idea behind this is to ignore tables that were
created by `pt-online-schema-change` or `gh-ost`. In addition it makes
sense to allow entire schemas to be ignored besides the system schemas