### PR TITLE
Comprehensive automated testing suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: required
+language: go
+go:
+  - "1.10.x"
+services:
+  - docker
+
+notifications:
+  email: false
+
+env:
+  global:
+    - SKEEMA_TEST_IMAGES="mysql:5.6,mysql:5.7"
+
+before_install:
+  - go get golang.org/x/lint/golint
+  - go get github.com/mattn/goveralls
+
+script:
+  - go test -v -coverprofile=coverage.out -covermode=count
+  - go vet ./...
+  - test -z "$(gofmt -s -d *.go 2>&1)"
+  - golint -set_exit_status .
+
+after_script:
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -235,11 +235,11 @@
 		},
 		{
 			"ImportPath": "github.com/skeema/mybase",
-			"Rev": "ee15b69d0631c5b93610a6119f7709a7d3a0121d"
+			"Rev": "59feabaee6bd70326153fa395ff06ee43a4f15dd"
 		},
 		{
 			"ImportPath": "github.com/skeema/tengo",
-			"Rev": "fd4524499ce9fdc7d87f96d02eacfc96f62e7f67"
+			"Rev": "9ee4eb030cd38ee874ed0d680a2b11289729254e"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ssh/terminal",

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ To download, build, and install Skeema, run:
 
 Skeema is currently in public beta.
 
-The `skeema` binary is supported on macOS and Linux. For now, it cannot be compiled on Windows. On the database side, testing has primarily been performed against MySQL 5.6, running on Linux.
+The `skeema` binary is supported on macOS and Linux. For now, it cannot be compiled on Windows. On the database side, testing is primarily performed against MySQL 5.6 and 5.7, running on Linux.
 
-Several InnoDB features (compression, partitioning, etc) and rare/new MySQL column types are not yet supported. Skeema is able to *create* or *drop* tables using these features, but not *alter* them. The output of `skeema diff` and `skeema push` clearly displays when this is the case. You may still make such alters directly/manually (outside of Skeema), and then update the corresponding CREATE TABLE files via `skeema pull`.
+Several MySQL features (foreign keys, partitioning) and rare/new MySQL column types are not yet supported. Skeema is able to *create* or *drop* tables using these features, but not *alter* them. The output of `skeema diff` and `skeema push` clearly displays when this is the case. You may still make such alters directly/manually (outside of Skeema), and then update the corresponding CREATE TABLE files via `skeema pull`.
 
 ## Credits
 

--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -31,8 +31,7 @@ differences were found, or 2+ if an error occurred.`
 
 // DiffHandler is the handler method for `skeema diff`
 func DiffHandler(cfg *mybase.Config) error {
-	// We just delegate to PushHandler, forcing dry-run to be enabled and always
-	// using concurrency of 1
+	// We just delegate to PushHandler, forcing dry-run to be enabled
 	cfg.CLI.OptionValues["dry-run"] = "1"
 	return PushHandler(cfg)
 }

--- a/cmd_lint.go
+++ b/cmd_lint.go
@@ -52,8 +52,8 @@ func LintHandler(cfg *mybase.Config) error {
 
 		if ignoreSchema, err := t.Dir.Config.GetRegexp("ignore-schema"); err != nil {
 			return err
-		} else if ignoreSchema != nil && ignoreSchema.MatchString(dir.String()) {
-			log.Warnf("Skipping schema %s because of ignore-schema='%s'", dir, ignoreSchema)
+		} else if ignoreSchema != nil && ignoreSchema.MatchString(t.SchemaFromDir.Name) {
+			log.Warnf("Skipping schema %s because of ignore-schema='%s'", t.SchemaFromDir.Name, ignoreSchema)
 			continue
 		}
 

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -71,7 +71,7 @@ func PushHandler(cfg *mybase.Config) error {
 		err = fmt.Errorf("concurrent-instances cannot be less than 1")
 	}
 	if err != nil {
-		return err
+		return NewExitValue(CodeBadConfig, err.Error())
 	}
 
 	// The 2nd param of dir.TargetGroups indicates that SQLFile errors are to be
@@ -197,17 +197,17 @@ func pushWorker(sps *sharedPushState) {
 			mods.AllowUnsafe = t.Dir.Config.GetBool("allow-unsafe") || sps.briefOutput
 			mods.AlgorithmClause, err = t.Dir.Config.GetEnum("alter-algorithm", "INPLACE", "COPY", "DEFAULT")
 			if err != nil {
-				sps.setFatalError(err)
+				sps.setFatalError(NewExitValue(CodeBadConfig, err.Error()))
 				return
 			}
 			mods.LockClause, err = t.Dir.Config.GetEnum("alter-lock", "NONE", "SHARED", "EXCLUSIVE", "DEFAULT")
 			if err != nil {
-				sps.setFatalError(err)
+				sps.setFatalError(NewExitValue(CodeBadConfig, err.Error()))
 				return
 			}
 			ignoreTable, err := t.Dir.Config.GetRegexp("ignore-table")
 			if err != nil {
-				sps.setFatalError(err)
+				sps.setFatalError(NewExitValue(CodeBadConfig, err.Error()))
 				return
 			}
 			for n, tableDiff := range diff.TableDiffs {

--- a/ddlstatement_test.go
+++ b/ddlstatement_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/skeema/mybase"
+	"github.com/skeema/tengo"
+)
+
+func (s *SkeemaIntegrationSuite) TestNewDDLStatement(t *testing.T) {
+	// Setup: init files and then change the DB so that we have some
+	// differences to generate. We first add a default value to domain col
+	// to later test that quoting rules are working properly for shellouts.
+	s.dbExec(t, "analytics", "ALTER TABLE pageviews MODIFY COLUMN domain varchar(40) NOT NULL DEFAULT 'skeema.net'")
+	s.handleCommand(t, CodeSuccess, ".", "skeema init --dir mydb -h %s -P %d", s.d.Instance.Host, s.d.Instance.Port)
+	s.sourceSQL(t, "ddlstatement.sql")
+
+	// Generate a diff a bit manually
+	fakeFileSource := mybase.SimpleSource(map[string]string{
+		"password":               s.d.Instance.Password,
+		"debug":                  "1",
+		"allow-unsafe":           "1",
+		"ddl-wrapper":            "/bin/echo ddl-wrapper {SCHEMA}.{TABLE} {TYPE}",
+		"alter-wrapper":          "/bin/echo alter-wrapper {SCHEMA}.{TABLE} {TYPE} {CLAUSES}",
+		"alter-wrapper-min-size": "1",
+		"alter-algorithm":        "INPLACE",
+		"alter-lock":             "NONE",
+	})
+	cfg := mybase.ParseFakeCLI(t, CommandSuite, "skeema diff ", fakeFileSource)
+	AddGlobalConfigFiles(cfg)
+	dir, err := NewDir(".", cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error from NewDir: %s", err)
+	}
+	var target *Target
+	for _, thisTarget := range dir.Targets() {
+		if thisTarget.SchemaFromInstance.Name == "analytics" {
+			target = thisTarget
+			break
+		}
+	}
+	sd, err := tengo.NewSchemaDiff(target.SchemaFromInstance, target.SchemaFromDir)
+	if err != nil {
+		t.Fatalf("Unexpected error from tengo.NewSchemaDiff: %s", err)
+	}
+	if len(sd.TableDiffs) != 4 {
+		// modifications in ddlstatement.sql should have yielded 4 diffs: one drop
+		// table, one create table, and two alter tables (one to a table with rows
+		// and one to a table without rows)
+		t.Fatalf("Expected 4 table diffs, instead found %d", len(sd.TableDiffs))
+	}
+
+	mods := tengo.StatementModifiers{
+		AllowUnsafe:     true,
+		LockClause:      "NONE",
+		AlgorithmClause: "INPLACE",
+	}
+	for _, diff := range sd.TableDiffs {
+		ddl := NewDDLStatement(diff, mods, target)
+		if ddl.Err != nil {
+			t.Errorf("Unexpected DDLStatement error: %s", ddl.Err)
+		}
+		if !ddl.IsShellOut() {
+			t.Fatalf("Expected this configuration to result in all DDLs being shellouts, but %v is not", ddl)
+		}
+		var expected string
+		switch diff := diff.(type) {
+		case tengo.AlterTable:
+			if diff.Table.Name == "rollups" {
+				// no rows, so ddl-wrapper used. verify the statement separately.
+				expected = "/bin/echo ddl-wrapper analytics.rollups ALTER"
+				expectedStmt := "ALTER TABLE `rollups` ALGORITHM=INPLACE, LOCK=NONE, ADD COLUMN `value` bigint(20) DEFAULT NULL"
+				if ddl.stmt != expectedStmt {
+					t.Errorf("Expected statement:\n%s\nActual statement:\n%s\n", expectedStmt, ddl.stmt)
+				}
+			} else if diff.Table.Name == "pageviews" {
+				// has 1 row, so alter-wrapper used. verify the execution separately to
+				// sanity-check the quoting rules.
+				expected = "/bin/echo alter-wrapper analytics.pageviews ALTER 'ADD COLUMN `domain` varchar(40) NOT NULL DEFAULT '\"'\"'skeema.net'\"'\"''"
+				expectedOutput := "alter-wrapper analytics.pageviews ALTER ADD COLUMN `domain` varchar(40) NOT NULL DEFAULT 'skeema.net'\n"
+				if actualOutput, err := ddl.shellOut.RunCapture(); err != nil || actualOutput != expectedOutput {
+					t.Errorf("Expected output:\n%sActual output:\n%sErr:\n%v\n", expectedOutput, actualOutput, err)
+				}
+			} else {
+				t.Fatalf("Unexpected AlterTable for %s; perhaps test fixture changed without updating this test?", diff.Table.Name)
+			}
+		case tengo.DropTable:
+			expected = "/bin/echo ddl-wrapper analytics.widget_counts DROP"
+		case tengo.CreateTable:
+			expected = "/bin/echo ddl-wrapper analytics.activity CREATE"
+		}
+		if ddl.shellOut.Command != expected {
+			t.Errorf("Expected shellout:\n%s\nActual shellout:\n%s\n", expected, ddl.shellOut.Command)
+		}
+	}
+}

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -59,9 +59,13 @@ When performing a large diff or push that affects dozens or hundreds of tables, 
 
 If a table uses a feature not supported by Skeema or its [Go La Tengo](https://github.com/skeema/tengo) automation library, such as compression or foreign keys, Skeema will refuse to generate ALTERs for the table. These cases are detected by comparing the output of `SHOW CREATE TABLE` to what Skeema thinks the generated CREATE TABLE should be, and flagging any discrepancies as tables that aren't supported for diffing or altering. This is noted in the output, and does not block execution of other schema changes. When in doubt, always check `skeema diff` as a safe dry-run prior to using `skeema push`.
 
+#### Extensive automated testing suite
+
+Skeema has an extensive suite of unit, integration, and functional tests; its library Tengo does as well. This suite includes testing against a Dockerized database instance of multiple versions of MySQL.
+
 #### Pedigree
 
-Skeema's author has been using MySQL for over 13 years, and is a former member of Facebook's elite team that maintains and automates the world's largest MySQL environment. Prior to Facebook, he started and led the database team at Tumblr, and created the open-source Ruby database automation library and shard-split tool [Jetpants](https://github.com/tumblr/jetpants). Rest assured that safety of data is baked into Skeema's DNA.
+Skeema's author has been using MySQL for over 15 years, and is a former member of Facebook's elite team that maintains and automates the world's largest MySQL environment. Prior to Facebook, he started and led the database team at Tumblr, and created the open-source Ruby database automation library and shard-split tool [Jetpants](https://github.com/tumblr/jetpants). Rest assured that safety of data is baked into Skeema's DNA.
 
 #### Responsibilities for the user
 

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -2,11 +2,11 @@
 
 ### MySQL version and flavor
 
-Skeema is currently being tested extensively against MySQL 5.6, running on Linux. Percona Server 5.6 should also work. Only the InnoDB storage engine is supported for now. 
+Skeema is tested extensively against MySQL 5.6 and 5.7, running on Linux. Percona Server 5.6 and 5.7 should also work fine. Only the InnoDB storage engine is primarily supported; other storage engines are often perfectly functional in Skeema, but it depends on whether any esoteric features of the engine are used.
 
-Skeema is also expected to work on slightly older (5.5) or newer (5.7) versions as well, but won't be able to diff tables that use new features such as generated/virtual columns. Skeema automatically detects this situation, so there is no risk of generating an incorrect diff. If Skeema does not yet support a table/column feature that you need, please open a GitHub issue so that the work can be prioritized appropriately.
+Some MySQL features -- such as foreign keys, partitioned tables, and generated/virtual columns -- are not yet supported in Skeema's diff operations. Skeema automatically detects this situation, so there is no risk of generating an incorrect diff. If Skeema does not yet support a table/column feature that you need, please open a GitHub issue so that the work can be prioritized appropriately.
 
-Skeema is not currently intended for use on multi-master systems, including Galera, InnoDB Cluster, and traditional active-active master-master configurations. It also has not yet been evaluated on Amazon Aurora.
+Skeema is not currently intended for use on multi-master replication topologies, including Galera, InnoDB Cluster, and traditional active-active master-master configurations. It also has not yet been evaluated on Amazon Aurora.
 
 ### Privileges
 
@@ -67,6 +67,8 @@ Many of these will be added in future releases.
 
 Skeema does not yet support connecting to MySQL using SSL.
 
+Due to protocol-level authentication changes, Skeema cannot interact with MySQL 8.0 yet. This will be fixed in the near future, as the Golang MySQL driver only added support for 8.0 connections very recently.
+
 #### Ignored by Skeema
 
 The following features are completely ignored by Skeema. Their presence in a schema won't immediately break anything, but Skeema will not interact with them. This means that `skeema init` and `skeema pull` won't create file representations of them; `skeema diff` and `skeema push` will not detect or alter them.
@@ -80,9 +82,8 @@ The following features are completely ignored by Skeema. Their presence in a sch
 Skeema can CREATE or DROP tables using these features, but cannot ALTER them. The output of `skeema diff` and `skeema push` will note that it cannot generate or run ALTER TABLE for tables using these features, so the affected table(s) will be skipped, but the rest of the operation will proceed as normal. 
 
 * foreign keys
-* compressed tables
 * partitioned tables
-* non-InnoDB storage engines
+* some features of non-InnoDB storage engines
 * fulltext indexes
 * spatial types
 * generated/virtual columns (MySQL 5.7+)

--- a/exit_test.go
+++ b/exit_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestExitCode(t *testing.T) {
+	err := errors.New("test error")
+	if ExitCode(err) != CodeFatalError {
+		t.Errorf("Expected exit code for non-nil non-ExitValue to be %d, instead found %d", CodeFatalError, ExitCode(err))
+	}
+	err = nil
+	if ExitCode(err) != CodeSuccess {
+		t.Errorf("Expected exit code for nil error to be %d, instead found %d", CodeSuccess, ExitCode(err))
+	}
+	err = NewExitValue(CodePartialError, "test error")
+	if ExitCode(err) != CodePartialError {
+		t.Errorf("Expected exit code to be %d, instead found %d", CodePartialError, ExitCode(err))
+	}
+}
+
+func TestExitValueError(t *testing.T) {
+	err := NewExitValue(CodeBadConfig, "test format string %s %t", "hello world", true)
+	expected := "test format string hello world true"
+	if actual := err.Error(); actual != expected {
+		t.Errorf("Found message %v, expected %v", actual, expected)
+	}
+	err = nil
+	expected = ""
+	if actual := err.Error(); actual != expected {
+		t.Errorf("Found message %v, expected %v", actual, expected)
+	}
+}

--- a/shellout.go
+++ b/shellout.go
@@ -173,7 +173,7 @@ func NewInterpolatedShellOut(command string, dir *Dir, extra map[string]string) 
 		resultWithoutPassword := varPlaceholder.ReplaceAllStringFunc(command, replacer)
 		return NewShellOut(result, resultWithoutPassword), err
 	}
-	return NewShellOut(result, result), err
+	return NewShellOut(result, ""), err
 }
 
 // escapeVarValue takes a string, and wraps it in single-quotes so that it will

--- a/shellout_test.go
+++ b/shellout_test.go
@@ -6,6 +6,22 @@ import (
 	"testing"
 )
 
+func TestShellOutRun(t *testing.T) {
+	assertResult := func(command string, expectSuccess bool) {
+		t.Helper()
+		s := NewShellOut(command, "")
+		if err := s.Run(); expectSuccess && err != nil {
+			t.Errorf("Expected command `%s` to return no error, but it returned error %s", command, err)
+		} else if !expectSuccess && err == nil {
+			t.Errorf("Expected command `%s` to return an error, but it did not", command)
+		}
+	}
+	assertResult("", false)
+	assertResult("false", false)
+	assertResult("/does/not/exist", false)
+	assertResult("true", true)
+}
+
 func TestRunCaptureSplit(t *testing.T) {
 	assertResult := func(command string, expectedTokens ...string) {
 		s := NewShellOut(command, "")
@@ -25,6 +41,16 @@ func TestRunCaptureSplit(t *testing.T) {
 	assertResult(`/usr/bin/printf ',,,commas,  have the,,next priority, if no newlines'`, "commas", "have the", "next priority", "if no newlines")
 	assertResult("/usr/bin/printf 'spaces    work  if no other   delimiters'", "spaces", "work", "if", "no", "other", "delimiters")
 	assertResult(`/usr/bin/printf 'intentionally "no support" for quotes'`, "intentionally", `"no`, `support"`, "for", "quotes")
+
+	// Test error responses
+	s := NewShellOut("", "")
+	if _, err := s.RunCaptureSplit(); err == nil {
+		t.Error("Expected empty shellout to error, but it did not")
+	}
+	s = NewShellOut("false", "")
+	if _, err := s.RunCaptureSplit(); err == nil {
+		t.Error("Expected non-zero exit code from shellout to error, but it did not")
+	}
 }
 
 func TestNewInterpolatedShellOut(t *testing.T) {

--- a/skeema.go
+++ b/skeema.go
@@ -24,14 +24,11 @@ func main() {
 	var cfg *mybase.Config
 
 	defer func() {
-		if err := recover(); err != nil {
-			if cfg == nil || !cfg.GetBool("debug") {
-				Exit(NewExitValue(CodeFatalError, fmt.Sprint(err)))
-			} else {
-				log.Error(err)
+		if iface := recover(); iface != nil {
+			if cfg != nil && cfg.GetBool("debug") {
 				log.Debug(string(debug.Stack()))
-				Exit(NewExitValue(CodeFatalError, ""))
 			}
+			Exit(NewExitValue(CodeFatalError, fmt.Sprint(iface)))
 		}
 	}()
 

--- a/skeema_test.go
+++ b/skeema_test.go
@@ -1,0 +1,408 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/skeema/mybase"
+	"github.com/skeema/tengo"
+)
+
+func TestMain(m *testing.M) {
+	// Suppress packet error output when attempting to connect to a Dockerized
+	// mysql-server which is still starting up
+	tengo.UseFilteredDriverLogger()
+
+	// Add global options to the global command suite, just like in main()
+	AddGlobalOptions(CommandSuite)
+
+	os.Exit(m.Run())
+}
+
+func TestIntegration(t *testing.T) {
+	images := tengo.SplitEnv("SKEEMA_TEST_IMAGES")
+	if len(images) == 0 {
+		// If SKEEMA_TEST_IMAGES isn't set, but TENGO_TEST_IMAGES is, fall back to that
+		images = tengo.SplitEnv("TENGO_TEST_IMAGES")
+	}
+	if len(images) == 0 {
+		fmt.Println("SKEEMA_TEST_IMAGES env var is not set, so integration tests will be skipped!")
+		fmt.Println("To run integration tests, you may set SKEEMA_TEST_IMAGES to a comma-separated")
+		fmt.Println("list of Docker images. Example:\n# SKEEMA_TEST_IMAGES=\"mysql:5.6,mysql:5.7\" go test")
+	}
+	tengo.RunSuite(&SkeemaIntegrationSuite{}, t, images)
+}
+
+type SkeemaIntegrationSuite struct {
+	d        *tengo.DockerizedInstance
+	repoPath string
+}
+
+func (s *SkeemaIntegrationSuite) Setup(backend string) (err error) {
+	// Remember working directory, which should be the base dir for the repo
+	s.repoPath, err = os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	// Spin up a Dockerized database server
+	s.d, err = tengo.CreateDockerizedInstance(backend)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *SkeemaIntegrationSuite) Teardown(backend string) error {
+	if err := s.d.Destroy(); err != nil {
+		return err
+	}
+	if err := os.Chdir(s.repoPath); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(s.workspace()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *SkeemaIntegrationSuite) BeforeTest(method string, backend string) error {
+	// Clear data and re-source setup data
+	if err := s.d.NukeData(); err != nil {
+		return err
+	}
+	if _, err := s.d.SourceSQL(s.testdata("setup.sql")); err != nil {
+		return err
+	}
+
+	// Create or recreate workspace dir
+	if _, err := os.Stat(s.workspace()); err == nil { // dir exists
+		if err := os.RemoveAll(s.workspace()); err != nil {
+			return err
+		}
+	}
+	if err := os.MkdirAll(s.workspace(), 0777); err != nil {
+		return err
+	}
+	if err := os.Chdir(s.workspace()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// testdata returns the absolute path of the testdata dir, or a file or dir
+// based from it
+func (s *SkeemaIntegrationSuite) testdata(joins ...string) string {
+	parts := append([]string{s.repoPath, "testdata"}, joins...)
+	return filepath.Join(parts...)
+}
+
+// workspace returns the workspace directory for tests to write temporary files
+// to.
+func (s *SkeemaIntegrationSuite) workspace() string {
+	return s.testdata(".tmpworkspace")
+}
+
+// handleCommand executes the supplied Skeema command-line, and confirms its exit
+// code matches the expected value.
+// pwd can specify a relative path (based off of testdata/.tmpworkspace) to
+// execute the command from the designated subdirectory. Afterwards, the pwd
+// will be restored to testdata/.tmpworkspace regardless.
+func (s *SkeemaIntegrationSuite) handleCommand(t *testing.T, expectedExitCode int, pwd, commandLine string, a ...interface{}) *mybase.Config {
+	t.Helper()
+
+	path := filepath.Join(s.workspace(), pwd)
+	if err := os.Chdir(path); err != nil {
+		t.Fatalf("Unable to cd to %s: %s", path, err)
+	}
+
+	fullCommandLine := fmt.Sprintf(commandLine, a...)
+	fmt.Fprintf(os.Stderr, "\x1b[37;1m%s$\x1b[0m %s\n", filepath.Join("testdata", ".tmpworkspace", pwd), fullCommandLine)
+	fakeFileSource := mybase.SimpleSource(map[string]string{"password": s.d.Instance.Password})
+	cfg := mybase.ParseFakeCLI(t, CommandSuite, fullCommandLine, fakeFileSource)
+	err := cfg.HandleCommand()
+	if actualExitCode := ExitCode(err); actualExitCode != expectedExitCode {
+		t.Errorf("Unexpected exit code from `%s`: Expected code=%d, found code=%d, message=%s", fullCommandLine, expectedExitCode, actualExitCode, err)
+	}
+	if pwd != "" && pwd != "." {
+		if err := os.Chdir(s.workspace()); err != nil {
+			t.Fatalf("Unable to cd to %s: %s", s.workspace(), err)
+		}
+	}
+	return cfg
+}
+
+// verifyFiles compares the files in testdata/.tmpworkspace to the files in the
+// specified dir, and fails the test if any differences are found.
+func (s *SkeemaIntegrationSuite) verifyFiles(t *testing.T, cfg *mybase.Config, dirExpectedBase string) {
+	t.Helper()
+
+	var compareDirs func(*Dir, *Dir)
+	compareDirs = func(a, b *Dir) {
+		t.Helper()
+
+		// Compare .skeema option files
+		if a.HasOptionFile() != b.HasOptionFile() {
+			t.Errorf("Presence of option files does not match between %s and %s", a, b)
+		}
+		if a.HasOptionFile() {
+			aOptionFile, err := a.OptionFile()
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			bOptionFile, err := b.OptionFile()
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			// Force port number of a to equal port number in b, since b will use whatever
+			// dynamic port was allocated to the Dockerized database instance
+			aSectionsWithPort := aOptionFile.SectionsWithOption("port")
+			bSectionsWithPort := bOptionFile.SectionsWithOption("port")
+			if !reflect.DeepEqual(aSectionsWithPort, bSectionsWithPort) {
+				t.Errorf("Sections with port option do not match between %s and %s", aOptionFile.Path(), bOptionFile.Path())
+			} else {
+				for _, section := range bSectionsWithPort {
+					bOptionFile.UseSection(section)
+					forcedValue, _ := bOptionFile.OptionValue("port")
+					aOptionFile.SetOptionValue(section, "port", forcedValue)
+				}
+			}
+
+			if !aOptionFile.SameContents(bOptionFile) {
+				t.Errorf("File contents do not match between %s and %s", aOptionFile.Path(), bOptionFile.Path())
+			}
+		}
+
+		// Compare *.sql files
+		aSQLFiles, err := a.SQLFiles()
+		if err != nil {
+			t.Fatalf("Unable to obtain *.sql from %s: %s", a, err)
+		}
+		bSQLFiles, err := b.SQLFiles()
+		if err != nil {
+			t.Fatalf("Unable to obtain *.sql from %s: %s", b, err)
+		}
+		if len(aSQLFiles) != len(bSQLFiles) {
+			t.Errorf("Differing count of *.sql files between %s and %s", a, b)
+		} else {
+			for n := range aSQLFiles {
+				if aSQLFiles[n].FileName != bSQLFiles[n].FileName || aSQLFiles[n].Contents != bSQLFiles[n].Contents {
+					diff := difflib.UnifiedDiff{
+						A:        difflib.SplitLines(aSQLFiles[n].Contents),
+						B:        difflib.SplitLines(bSQLFiles[n].Contents),
+						FromFile: aSQLFiles[n].Path(),
+						ToFile:   bSQLFiles[n].Path(),
+						Context:  0,
+					}
+					diffText, err := difflib.GetUnifiedDiffString(diff)
+					if err == nil {
+						for _, line := range strings.Split(diffText, "\n") {
+							if len(line) > 0 {
+								t.Log(line)
+							}
+						}
+					}
+					t.Errorf("Difference found in %s vs %s", aSQLFiles[n].Path(), bSQLFiles[n].Path())
+				}
+			}
+		}
+
+		// Compare subdirs and walk them
+		aSubdirs, err := a.Subdirs()
+		if err != nil {
+			t.Fatalf("Unable to list subdirs of %s: %s", a, err)
+		}
+		bSubdirs, err := b.Subdirs()
+		if err != nil {
+			t.Fatalf("Unable to list subdirs of %s: %s", b, err)
+		}
+		if len(aSubdirs) != len(bSubdirs) {
+			t.Errorf("Differing count of subdirs between %s and %s", a, b)
+		} else {
+			for n := range aSubdirs {
+				if aSubdirs[n].BaseName() != bSubdirs[n].BaseName() {
+					t.Errorf("Subdir name mismatch: %s vs %s", aSubdirs[n], bSubdirs[n])
+				} else {
+					compareDirs(aSubdirs[n], bSubdirs[n])
+				}
+			}
+		}
+	}
+
+	expected, err := NewDir(dirExpectedBase, cfg)
+	if err != nil {
+		t.Fatalf("NewDir(%s) returned %s", dirExpectedBase, err)
+	}
+	actual, err := NewDir(s.workspace(), cfg)
+	if err != nil {
+		t.Fatalf("NewDir(%s) returned %s", s.workspace(), err)
+	}
+	compareDirs(expected, actual)
+}
+
+func (s *SkeemaIntegrationSuite) reinitAndVerifyFiles(t *testing.T, extraInitOpts, comparePath string) {
+	t.Helper()
+
+	if comparePath == "" {
+		comparePath = "../golden/init"
+	}
+	if err := os.RemoveAll("mydb"); err != nil {
+		t.Fatalf("Unable to clean directory: %s", err)
+	}
+	cfg := s.handleCommand(t, CodeSuccess, ".", "skeema init --dir mydb -h %s -P %d %s", s.d.Instance.Host, s.d.Instance.Port, extraInitOpts)
+	s.verifyFiles(t, cfg, comparePath)
+}
+
+func (s *SkeemaIntegrationSuite) assertExists(t *testing.T, schema, table, column string) {
+	t.Helper()
+	exists, phrase, err := s.objectExists(schema, table, column)
+	if err != nil {
+		t.Fatalf("Unexpected error checking existence of %s: %s", phrase, err)
+	}
+	if !exists {
+		t.Errorf("Expected %s to exist, but it does not", phrase)
+	}
+}
+
+func (s *SkeemaIntegrationSuite) assertMissing(t *testing.T, schema, table, column string) {
+	t.Helper()
+	exists, phrase, err := s.objectExists(schema, table, column)
+	if err != nil {
+		t.Fatalf("Unexpected error checking existence of %s: %s", phrase, err)
+	}
+	if exists {
+		t.Errorf("Expected %s to not exist, but it does", phrase)
+	}
+}
+
+func (s *SkeemaIntegrationSuite) objectExists(schemaName, tableName, columnName string) (exists bool, phrase string, err error) {
+	if schemaName == "" || (tableName == "" && columnName != "") {
+		panic(errors.New("Invalid parameter combination"))
+	}
+	if tableName == "" && columnName == "" {
+		phrase = fmt.Sprintf("schema %s", schemaName)
+	} else if columnName == "" {
+		phrase = fmt.Sprintf("table %s.%s", schemaName, tableName)
+	} else {
+		phrase = fmt.Sprintf("column %s.%s.%s", schemaName, tableName, columnName)
+	}
+
+	schema, err := s.d.Schema(schemaName)
+	if tableName == "" && columnName == "" {
+		return schema != nil, phrase, err
+	} else if err != nil {
+		return false, phrase, fmt.Errorf("Unable to obtain %s: %s", phrase, err)
+	}
+
+	table, err := schema.Table(tableName)
+	if columnName == "" {
+		return table != nil, phrase, err
+	} else if err != nil {
+		return false, phrase, fmt.Errorf("Unable to obtain %s: %s", phrase, err)
+	}
+
+	columns := table.ColumnsByName()
+	_, exists = columns[columnName]
+	return exists, phrase, nil
+}
+
+// sourceSQL wraps tengo.DockerizedInstance.SourceSQL. If an error occurs, it is
+// fatal to the test. filePath should be a relative path based from testdata/.
+func (s *SkeemaIntegrationSuite) sourceSQL(t *testing.T, filePath string) {
+	t.Helper()
+	filePath = filepath.Join("..", filePath)
+	if _, err := s.d.SourceSQL(filePath); err != nil {
+		t.Fatalf("Unable to source %s: %s", filePath, err)
+	}
+}
+
+// cleanData wraps tengo.DockerizedInstance.NukeData. If an error occurs, it is
+// fatal to the test. To automatically source one or more *.sql files after
+// nuking the data, supply relative file paths as args.
+func (s *SkeemaIntegrationSuite) cleanData(t *testing.T, sourceAfter ...string) {
+	t.Helper()
+	if err := s.d.NukeData(); err != nil {
+		t.Fatalf("Unable to clear database state: %s", err)
+	}
+	for _, filePath := range sourceAfter {
+		s.sourceSQL(t, filePath)
+	}
+}
+
+// dbExec runs the specified SQL DML or DDL in the specified schema. If
+// something goes wrong, it is fatal to the current test.
+func (s *SkeemaIntegrationSuite) dbExec(t *testing.T, schemaName, query string, args ...interface{}) {
+	t.Helper()
+	db, err := s.d.Connect(schemaName, "")
+	if err != nil {
+		t.Fatalf("Unable to connect to DockerizedInstance: %s", err)
+	}
+	_, err = db.Exec(query, args...)
+	if err != nil {
+		t.Fatalf("Error running query on DockerizedInstance.\nSchema: %s\nQuery: %s\nError: %s", schemaName, query, err)
+	}
+	if schemaName != "" {
+		if schema, err := s.d.Schema(schemaName); err == nil {
+			schema.PurgeTableCache()
+		}
+	}
+}
+
+// readFile wraps ioutil.ReadFile, with any errors being fatal to the test.
+func readFile(t *testing.T, filename string) string {
+	t.Helper()
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("Unable to read %s: %s", filename, err)
+	}
+	return string(contents)
+}
+
+// writeFile wraps ioutil.WriteFile, with any errors being fatal to the test.
+func writeFile(t *testing.T, filename, contents string) {
+	t.Helper()
+	dirPath := filepath.Dir(filename)
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+		err = os.MkdirAll(dirPath, 0777)
+		if err != nil {
+			t.Fatalf("Unable to create directory %s: %s", dirPath, err)
+		}
+	}
+
+	err := ioutil.WriteFile(filename, []byte(contents), 0777)
+	if err != nil {
+		t.Fatalf("Unable to write %s: %s", filename, err)
+	}
+}
+
+// makeDir wraps os.MkdirAll, with any errors being fatal to the test.
+func makeDir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0777); err != nil {
+		t.Fatalf("Unable to create dir: %s", err)
+	}
+}
+
+// getOptionFile returns a mybase.File representing the .skeema file in the
+// specified directory
+func getOptionFile(t *testing.T, basePath string, baseConfig *mybase.Config) *mybase.File {
+	t.Helper()
+	dir, err := NewDir(basePath, baseConfig)
+	if err != nil {
+		t.Fatalf("Unable to obtain directory %s: %s", basePath, err)
+	}
+	file, err := dir.OptionFile()
+	if err != nil {
+		t.Fatalf("Unable to obtain %s/.skeema: %s", basePath, err)
+	}
+	return file
+}

--- a/sqlfile_test.go
+++ b/sqlfile_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/skeema/mybase"
+)
+
+func getWorkspaceDir(t *testing.T) *Dir {
+	t.Helper()
+	cmd := mybase.NewCommand("test", "1.0", "this is for testing", nil)
+	cli := &mybase.CommandLine{
+		Command: cmd,
+	}
+	cfg := mybase.NewConfig(cli)
+	dirPath, _ := filepath.Abs("testdata/.workspace")
+	if _, err := os.Stat(dirPath); err == nil { // dir exists
+		if err := os.RemoveAll(dirPath); err != nil {
+			t.Fatalf("Unable to remove workspace dir: %s", err)
+		}
+	}
+	if err := os.MkdirAll(dirPath, 0777); err != nil {
+		t.Fatalf("Unable to create workspace dir: %s", err)
+	}
+	return &Dir{
+		Path:    dirPath,
+		Config:  cfg,
+		section: "production",
+	}
+}
+
+func TestSQLFileIO(t *testing.T) {
+	sf := SQLFile{
+		Dir:      getWorkspaceDir(t),
+		FileName: "something.sql",
+	}
+
+	// Read should fail if file does not exist
+	if _, err := sf.Read(); err == nil {
+		t.Error("Expected read on nonexistent SQLFile to return error, but it did not")
+	}
+
+	// Write should fail if file has no contents
+	if bytes, err := sf.Write(); err == nil {
+		t.Errorf("Expected write to fail with no contents, but instead %d bytes written without error", bytes)
+	}
+
+	// Write should fail if file has contents but no .sql extension
+	sf.FileName = "something.nosql"
+	sf.Contents = "contents not validated by write"
+	if bytes, err := sf.Write(); err == nil {
+		t.Errorf("Expected write to fail with non-.sql extension, but instead %d bytes written without error", bytes)
+	}
+
+	// Write should fail if the file's dir doesn't exist
+	oldDirPath := sf.Dir.Path
+	sf.Dir.Path += "xyz"
+	if bytes, err := sf.Write(); err == nil {
+		t.Errorf("Expected write to fail with invalid dir path, but instead %d bytes written without error", bytes)
+	}
+	sf.Dir.Path = oldDirPath
+
+	// Write should succeed if non-empty (but invalid) contents and .sql extension,
+	// but subsequent read should error due to the invalid contents
+	sf.FileName = "something.sql"
+	if _, err := sf.Write(); err != nil {
+		t.Fatalf("Expected write to succeed, but instead returned error %s", err)
+	}
+	if _, err := sf.Read(); err == nil {
+		t.Error("Expected read on SQLFile with invalid contents to return error, but it did not")
+	}
+
+	// Read should succeed if contents are a valid CREATE TABLE
+	writeFile(t, sf.Path(), "CREATE TABLE whatever (id int NOT NULL) ENGINE=InnoDB;\n")
+	if _, err := sf.Read(); err != nil {
+		t.Errorf("Expected read to succeed, but instead returned error %s", err)
+	}
+
+	// Delete should succeed when file exists, and fail when it does not
+	if err := sf.Delete(); err != nil {
+		t.Errorf("Expected delete to succeed, but instead returned error %s", err)
+	}
+	if _, err := sf.Read(); err == nil {
+		t.Error("Expected read on deleted SQLFile to return error, but it did not")
+	}
+	if err := sf.Delete(); err == nil {
+		t.Error("Expected delete on already-deleted SQLFile to return error, but it did not")
+	}
+
+	// Clean up
+	if err := sf.Dir.Delete(); err != nil {
+		t.Fatalf("Unexpected error from deleting workspace dir: %s", err)
+	}
+}
+
+func TestSQLFileValidateContents(t *testing.T) {
+	sf := SQLFile{
+		Dir:      getWorkspaceDir(t),
+		FileName: "something.sql",
+	}
+	assertValidation := func(contents string, expectedErrors, expectedWarnings int) {
+		t.Helper()
+		sf.Contents = contents
+		err := sf.validateContents()
+		if err != sf.Error {
+			t.Fatalf("Expected returned error to match field, but found return=%s, sf.Error=%s", err, sf.Error)
+		}
+		if err == nil && expectedErrors != 0 {
+			t.Errorf("Expected %d error, but instead found 0", expectedErrors)
+		} else if err != nil && expectedErrors != 1 {
+			t.Errorf("Expected %d errors, but instead found 1: %s", expectedErrors, err)
+		}
+		if len(sf.Warnings) != expectedWarnings {
+			t.Errorf("Expected %d warnings, but instead found %d: %v", expectedWarnings, len(sf.Warnings), sf.Warnings)
+		}
+	}
+
+	assertValidation(strings.Repeat("x", MaxSQLFileSize+1), 1, 0)
+	assertValidation("no create table here", 1, 0)
+	assertValidation("# comment\nCREATE TABLE something (id int);\nrandom stuff after\n", 0, 1)
+	assertValidation("CREATE TABLE foo (id int);\n", 0, 1)
+	assertValidation("CREATE TABLE something AS SELECT 1;", 1, 0)
+	assertValidation("CREATE TABLE something \n  SELECT   1;", 1, 0)
+	assertValidation("CREATE TABLE something    LIKE   other_table;", 1, 0)
+	assertValidation("CREATE TABLE something (LIKE other_table);", 1, 0)
+	assertValidation("# comment\nCREATE TABLE IF NOT EXISTS foo SELECT 1", 1, 2)
+	assertValidation("CREATE TABLE something (id int)", 0, 0)
+	assertValidation("CREATE TABLE something (id int);\n", 0, 0)
+	assertValidation("CREATE  TaBLE  iF   NOT    exists `something` (id int);", 0, 0)
+}

--- a/testdata/ddlstatement.sql
+++ b/testdata/ddlstatement.sql
@@ -1,0 +1,11 @@
+use analytics
+CREATE TABLE widget_counts (
+  name varchar(40) NOT NULL,
+  cnt int unsigned,
+  PRIMARY KEY (name)
+) ENGINE=InnoDB;
+DROP TABLE activity;
+ALTER TABLE rollups DROP COLUMN value;
+ALTER TABLE pageviews DROP COLUMN domain;
+INSERT INTO pageviews (url, start_ts, end_ts) VALUES ("foo.html", 123, 456);
+

--- a/testdata/golden/autoinc/mydb/.skeema
+++ b/testdata/golden/autoinc/mydb/.skeema
@@ -1,0 +1,3 @@
+[production]
+host=127.0.0.1
+port={DYNAMICALLY INSERTED BY TEST}

--- a/testdata/golden/autoinc/mydb/analytics/.skeema
+++ b/testdata/golden/autoinc/mydb/analytics/.skeema
@@ -1,0 +1,1 @@
+schema=analytics

--- a/testdata/golden/autoinc/mydb/analytics/activity.sql
+++ b/testdata/golden/autoinc/mydb/analytics/activity.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/autoinc/mydb/analytics/pageviews.sql
+++ b/testdata/golden/autoinc/mydb/analytics/pageviews.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/autoinc/mydb/analytics/rollups.sql
+++ b/testdata/golden/autoinc/mydb/analytics/rollups.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/autoinc/mydb/product/.skeema
+++ b/testdata/golden/autoinc/mydb/product/.skeema
@@ -1,0 +1,1 @@
+schema=product

--- a/testdata/golden/autoinc/mydb/product/comments.sql
+++ b/testdata/golden/autoinc/mydb/product/comments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `comments` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `body` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/autoinc/mydb/product/posts.sql
+++ b/testdata/golden/autoinc/mydb/product/posts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `edited_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/autoinc/mydb/product/subscriptions.sql
+++ b/testdata/golden/autoinc/mydb/product/subscriptions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `subscriptions` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/autoinc/mydb/product/users.sql
+++ b/testdata/golden/autoinc/mydb/product/users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT '10.00',
+  `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=latin1;

--- a/testdata/golden/ignore/mydb/.skeema
+++ b/testdata/golden/ignore/mydb/.skeema
@@ -1,0 +1,5 @@
+[production]
+host=127.0.0.1
+port={DYNAMICALLY INSERTED BY TEST}
+ignore-schema=^archives$
+ignore-table=^_

--- a/testdata/golden/ignore/mydb/analytics/.skeema
+++ b/testdata/golden/ignore/mydb/analytics/.skeema
@@ -1,0 +1,1 @@
+schema=analytics

--- a/testdata/golden/ignore/mydb/analytics/activity.sql
+++ b/testdata/golden/ignore/mydb/analytics/activity.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/ignore/mydb/analytics/pageviews.sql
+++ b/testdata/golden/ignore/mydb/analytics/pageviews.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/ignore/mydb/analytics/rollups.sql
+++ b/testdata/golden/ignore/mydb/analytics/rollups.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/ignore/mydb/product/.skeema
+++ b/testdata/golden/ignore/mydb/product/.skeema
@@ -1,0 +1,1 @@
+schema=product

--- a/testdata/golden/ignore/mydb/product/comments.sql
+++ b/testdata/golden/ignore/mydb/product/comments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `comments` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `body` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/ignore/mydb/product/posts.sql
+++ b/testdata/golden/ignore/mydb/product/posts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `edited_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/ignore/mydb/product/subscriptions.sql
+++ b/testdata/golden/ignore/mydb/product/subscriptions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `subscriptions` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/ignore/mydb/product/users.sql
+++ b/testdata/golden/ignore/mydb/product/users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT '10.00',
+  `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/init/mydb/.skeema
+++ b/testdata/golden/init/mydb/.skeema
@@ -1,0 +1,3 @@
+[production]
+host=127.0.0.1
+port={DYNAMICALLY INSERTED BY TEST}

--- a/testdata/golden/init/mydb/analytics/.skeema
+++ b/testdata/golden/init/mydb/analytics/.skeema
@@ -1,0 +1,1 @@
+schema=analytics

--- a/testdata/golden/init/mydb/analytics/activity.sql
+++ b/testdata/golden/init/mydb/analytics/activity.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/init/mydb/analytics/pageviews.sql
+++ b/testdata/golden/init/mydb/analytics/pageviews.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/init/mydb/analytics/rollups.sql
+++ b/testdata/golden/init/mydb/analytics/rollups.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/init/mydb/product/.skeema
+++ b/testdata/golden/init/mydb/product/.skeema
@@ -1,0 +1,1 @@
+schema=product

--- a/testdata/golden/init/mydb/product/comments.sql
+++ b/testdata/golden/init/mydb/product/comments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `comments` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `body` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/init/mydb/product/posts.sql
+++ b/testdata/golden/init/mydb/product/posts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `edited_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/init/mydb/product/subscriptions.sql
+++ b/testdata/golden/init/mydb/product/subscriptions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `subscriptions` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/init/mydb/product/users.sql
+++ b/testdata/golden/init/mydb/product/users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT '10.00',
+  `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/pull1/mydb/.skeema
+++ b/testdata/golden/pull1/mydb/.skeema
@@ -1,0 +1,3 @@
+[production]
+host=127.0.0.1
+port={DYNAMICALLY INSERTED BY TEST}

--- a/testdata/golden/pull1/mydb/analytics/.skeema
+++ b/testdata/golden/pull1/mydb/analytics/.skeema
@@ -1,0 +1,3 @@
+schema=analytics
+default-character-set=utf8
+default-collation=utf8_swedish_ci

--- a/testdata/golden/pull1/mydb/analytics/activity.sql
+++ b/testdata/golden/pull1/mydb/analytics/activity.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/pull1/mydb/analytics/pageviews.sql
+++ b/testdata/golden/pull1/mydb/analytics/pageviews.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/pull1/mydb/analytics/rollups.sql
+++ b/testdata/golden/pull1/mydb/analytics/rollups.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/pull1/mydb/analytics/widget_counts.sql
+++ b/testdata/golden/pull1/mydb/analytics/widget_counts.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `widget_counts` (
+  `name` varchar(40) NOT NULL,
+  `cnt` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/pull1/mydb/archives/.skeema
+++ b/testdata/golden/pull1/mydb/archives/.skeema
@@ -1,0 +1,3 @@
+schema=archives
+default-character-set=utf8mb4
+default-collation=utf8mb4_general_ci

--- a/testdata/golden/pull1/mydb/archives/foo.sql
+++ b/testdata/golden/pull1/mydb/archives/foo.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `foo` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/testdata/golden/pull1/mydb/product/.skeema
+++ b/testdata/golden/pull1/mydb/product/.skeema
@@ -1,0 +1,1 @@
+schema=product

--- a/testdata/golden/pull1/mydb/product/posts.sql
+++ b/testdata/golden/pull1/mydb/product/posts.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `edited_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `status` varchar(20) DEFAULT 'published',
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/pull1/mydb/product/subscriptions.sql
+++ b/testdata/golden/pull1/mydb/product/subscriptions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `subscriptions` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/pull1/mydb/product/users.sql
+++ b/testdata/golden/pull1/mydb/product/users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT '10.00',
+  `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/unsupported/mydb/.skeema
+++ b/testdata/golden/unsupported/mydb/.skeema
@@ -1,0 +1,3 @@
+[production]
+host=127.0.0.1
+port={DYNAMICALLY INSERTED BY TEST}

--- a/testdata/golden/unsupported/mydb/analytics/.skeema
+++ b/testdata/golden/unsupported/mydb/analytics/.skeema
@@ -1,0 +1,1 @@
+schema=analytics

--- a/testdata/golden/unsupported/mydb/analytics/activity.sql
+++ b/testdata/golden/unsupported/mydb/analytics/activity.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/unsupported/mydb/analytics/pageviews.sql
+++ b/testdata/golden/unsupported/mydb/analytics/pageviews.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/unsupported/mydb/analytics/rollups.sql
+++ b/testdata/golden/unsupported/mydb/analytics/rollups.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/unsupported/mydb/product/.skeema
+++ b/testdata/golden/unsupported/mydb/product/.skeema
@@ -1,0 +1,1 @@
+schema=product

--- a/testdata/golden/unsupported/mydb/product/comments.sql
+++ b/testdata/golden/unsupported/mydb/product/comments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `comments` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `body` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/unsupported/mydb/product/posts.sql
+++ b/testdata/golden/unsupported/mydb/product/posts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `edited_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/unsupported/mydb/product/subscriptions.sql
+++ b/testdata/golden/unsupported/mydb/product/subscriptions.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `subscriptions` (
+  `subscription_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`),
+  KEY `sub_id_user` (`subscription_id`,`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+/*!50100 PARTITION BY RANGE (user_id)
+(PARTITION p0 VALUES LESS THAN (123) ENGINE = InnoDB,
+ PARTITION p1 VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */;

--- a/testdata/golden/unsupported/mydb/product/users.sql
+++ b/testdata/golden/unsupported/mydb/product/users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT '10.00',
+  `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/ignore1.sql
+++ b/testdata/ignore1.sql
@@ -1,0 +1,21 @@
+use product
+CREATE TABLE _widgets (
+  id int unsigned NOT NULL AUTO_INCREMENT,
+  name varchar(30),
+  PRIMARY KEY (id),
+  UNIQUE KEY name_idx (name)
+) ENGINE=InnoDB;
+
+use analytics
+CREATE TABLE _trending (
+  content_id int unsigned NOT NULL,
+  content_type char(10) NOT NULL,
+  PRIMARY KEY (content_id, content_type)
+) ENGINE=InnoDB;
+
+CREATE DATABASE archives CHARACTER SET utf8mb4;
+use archives
+CREATE TABLE foo (
+ id int unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY
+) ENGINE=InnoDB;
+

--- a/testdata/pull1.sql
+++ b/testdata/pull1.sql
@@ -1,0 +1,18 @@
+use product
+ALTER TABLE posts ADD COLUMN status varchar(20) DEFAULT 'published';
+DROP TABLE comments;
+
+use analytics
+CREATE TABLE widget_counts (
+  name varchar(40) NOT NULL,
+  cnt int unsigned,
+  PRIMARY KEY (name)
+) ENGINE=InnoDB;
+ALTER DATABASE analytics CHARACTER SET utf8 COLLATE utf8_swedish_ci;
+
+CREATE DATABASE archives CHARACTER SET utf8mb4;
+use archives
+CREATE TABLE foo (
+  id int unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY
+) ENGINE=InnoDB;
+

--- a/testdata/push1.sql
+++ b/testdata/push1.sql
@@ -1,0 +1,17 @@
+use analytics
+CREATE TABLE widget_counts (
+  name varchar(40) NOT NULL,
+  cnt int unsigned,
+  PRIMARY KEY (name)
+) ENGINE=InnoDB;
+INSERT INTO widget_counts (name, cnt) VALUES ('foobar', 123);
+ALTER TABLE pageviews DROP COLUMN domain;
+ALTER TABLE activity ADD COLUMN rolled_up tinyint(1) unsigned NOT NULL;
+ALTER DATABASE analytics CHARACTER SET utf8 COLLATE utf8_swedish_ci;
+
+CREATE DATABASE bonus;
+use bonus;
+CREATE TABLE placeholder (
+  id int unsigned NOT NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB;

--- a/testdata/setup.sql
+++ b/testdata/setup.sql
@@ -1,0 +1,67 @@
+CREATE DATABASE product;
+USE product
+
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT '10.00',
+  `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `edited_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE `comments` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `body` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE `subscriptions` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+
+CREATE DATABASE analytics;
+USE analytics
+
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/unsupported1.sql
+++ b/testdata/unsupported1.sql
@@ -1,0 +1,10 @@
+use product
+ALTER TABLE subscriptions
+  ADD COLUMN subscription_id int(10) unsigned NOT NULL AUTO_INCREMENT FIRST,
+  ADD KEY sub_id_user (subscription_id, user_id),
+  AUTO_INCREMENT=456
+  PARTITION BY RANGE (user_id) (
+    PARTITION p0 VALUES LESS THAN (123),
+    PARTITION p1 VALUES LESS THAN MAXVALUE
+  )
+;

--- a/vendor/github.com/skeema/mybase/config.go
+++ b/vendor/github.com/skeema/mybase/config.go
@@ -22,6 +22,7 @@ type OptionValuer interface {
 // OptionValuer interface.
 type Config struct {
 	CLI            *CommandLine            // Parsed command-line
+	IsTest         bool                    // true if Config generated from test logic, false otherwise
 	sources        []OptionValuer          // Sources of option values, excluding CLI or Command; higher indexes override lower indexes
 	unifiedValues  map[string]string       // Precomputed cache of option name => value
 	unifiedSources map[string]OptionValuer // Precomputed cache of option name => which source supplied it

--- a/vendor/github.com/skeema/mybase/file.go
+++ b/vendor/github.com/skeema/mybase/file.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"unicode"
 )
@@ -290,6 +291,19 @@ func (f *File) SetOptionValue(sectionName, optionName, value string) {
 func (f *File) UnsetOptionValue(sectionName, optionName string) {
 	section := f.getOrCreateSection(sectionName)
 	delete(section.Values, optionName)
+}
+
+// SameContents returns true if f and other have the same sections and values.
+// Ordering, formatting, comments, filename, and directory do not affect the
+// results of this comparison. Both files must be parsed by the caller prior
+// to calling this method, otherwise this method panics to indicate programmer
+// error.
+// This method is primarily intended for unit testing purposes.
+func (f *File) SameContents(other *File) bool {
+	if !f.parsed || !other.parsed {
+		panic(errors.New("File.SameContents called on a file that has not yet been parsed"))
+	}
+	return reflect.DeepEqual(f.sectionIndex, other.sectionIndex)
 }
 
 func (f *File) getOrCreateSection(name string) *Section {

--- a/vendor/github.com/skeema/mybase/testing.go
+++ b/vendor/github.com/skeema/mybase/testing.go
@@ -33,6 +33,7 @@ func ParseFakeCLI(t *testing.T, cmd *Command, commandLine string, sources ...Opt
 	for _, src := range sources {
 		cfg.AddSource(src)
 	}
+	cfg.IsTest = true
 	return cfg
 }
 


### PR DESCRIPTION
This PR adds an integration test suite for Skeema, including many new tests that run against a Dockerized copy of mysql-server. This PR increases test code coverage from 18% previously to now 83%. It also adds integration with [Travis CI](https://travis-ci.org/skeema/skeema) and [Coveralls](https://coveralls.io/github/skeema/skeema).

The test suite can be run locally if Docker is installed. Simply define the `SKEEMA_TEST_IMAGES` env var to a comma-separated list of Docker images to test against; for example:
```
export SKEEMA_TEST_IMAGES="mysql:5.6,mysql:5.7"
go test -v
```

If Docker isn't available locally and/or `SKEEMA_TEST_IMAGES` isn't defined, only the basic unit tests (which don't require connecting to an actual mysql-server) are run by `go test`.
