### PR TITLE
Support index reordering; add new --exact-match option

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -152,7 +152,7 @@
   branch = "master"
   name = "github.com/skeema/tengo"
   packages = ["."]
-  revision = "ba3e8ce6ebae7abdaae18d7fca1fe5b56304cd04"
+  revision = "eeee978997419f1a9eb03f62fbd3dd858c3f9c2a"
 
 [[projects]]
   branch = "master"

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -29,6 +29,7 @@ top of the file. If no environment name is supplied, the default is
 	cmd.AddOption(mybase.BoolOption("allow-unsafe", 0, false, "Permit running ALTER or DROP operations that are potentially destructive"))
 	cmd.AddOption(mybase.BoolOption("dry-run", 0, false, "Output DDL but don't run it; equivalent to `skeema diff`"))
 	cmd.AddOption(mybase.BoolOption("first-only", '1', false, "For dirs mapping to multiple instances or schemas, just run against the first per dir"))
+	cmd.AddOption(mybase.BoolOption("exact-match", 0, false, "Follow *.sql table definitions exactly, even for differences with no functional impact"))
 	cmd.AddOption(mybase.BoolOption("brief", 'q', false, "<overridden by diff command>").Hidden())
 	cmd.AddOption(mybase.StringOption("alter-wrapper", 'x', "", "External bin to shell out to for ALTER TABLE; see manual for template vars"))
 	cmd.AddOption(mybase.StringOption("alter-wrapper-min-size", 0, "0", "Ignore --alter-wrapper for tables smaller than this size in bytes"))
@@ -192,6 +193,7 @@ func pushWorker(sps *sharedPushState) {
 			// Set configuration-dependent statement modifiers here inside the Target
 			// loop, since the config for these may var per dir!
 			mods.AllowUnsafe = t.Dir.Config.GetBool("allow-unsafe") || sps.briefOutput
+			mods.StrictIndexOrder = t.Dir.Config.GetBool("exact-match")
 			mods.AlgorithmClause, err = t.Dir.Config.GetEnum("alter-algorithm", "INPLACE", "COPY", "DEFAULT")
 			if err != nil {
 				sps.setFatalError(NewExitValue(CodeBadConfig, err.Error()))

--- a/doc/options.md
+++ b/doc/options.md
@@ -16,6 +16,7 @@
 * [default-collation](#default-collation)
 * [dir](#dir)
 * [dry-run](#dry-run)
+* [exact-match](#exact-match)
 * [first-only](#first-only)
 * [host](#host)
 * [host-wrapper](#host-wrapper)
@@ -295,6 +296,24 @@ Commands | push
 
 Running `skeema push --dry-run` is exactly equivalent to running `skeema diff`: the DDL will be generated and printed, but not executed. The same code path is used in both cases. The *only* difference is that `skeema diff` has its own help/usage text, but otherwise the command logic is the same as `skeema push --dry-run`.
 
+### exact-match
+
+Commands | diff, push
+--- | :---
+**Default** | false
+**Type** | boolean
+**Restrictions** | none
+
+Ordinarily, `skeema diff` and `skeema push` ignore certain table differences which have no functional impact in MySQL and serve purely cosmetic purposes. For example, if two tables list their indexes in a different order, this difference is normally ignored to avoid needlessly dropping and re-adding the indexes, which may be slow if the table is large.
+
+If the [exact-match](#exact-match) option is used, these purely-cosmetic differences will be included in the generated `ALTER TABLE` statements instead of being suppressed. In other words, Skeema will attempt to make the exact table definition in MySQL exactly match the corresponding table definition specified in the *.sql file.
+
+Be aware that MySQL itself sometimes also suppresses attempts to make cosmetic changes to a table's definition! You must combine the [exact-match](#exact-match) option with [alter-algorithm=COPY](#alter-algorithm) to circumvent this behavior on the MySQL side. This forces MySQL to rebuild the table, which will be slow for large tables.
+
+Currently, [exact-match](#exact-match) only affects index ordering. In the near future, once foreign keys are supported, this option will affect foreign key naming and ordering as well.
+
+In the one case in InnoDB when index ordering has a functional impact (tables with no primary key, but multiple unique indexes over all non-nullable columns), Skeema will automatically respect index ordering, regardless of whether [exact-match](#exact-match) is enabled.
+
 ### first-only
 
 Commands | diff, push
@@ -540,4 +559,4 @@ Commands | diff, push
 
 Controls whether generated `ALTER TABLE` statements are automatically verified for correctness. If true, each generated ALTER will be tested in the temporary schema. See [the FAQ](faq.md#auto-generated-ddl-is-verified-for-correctness) for more information.
 
-It is recommended that this variable be left at its default of true, but if desired you can disable verification for speed reasons.
+It is recommended that this option be left at its default of true, but if desired you can disable verification for performance reasons.

--- a/skeema_cmd_test.go
+++ b/skeema_cmd_test.go
@@ -620,7 +620,7 @@ func (s *SkeemaIntegrationSuite) TestNonInnoClauses(t *testing.T) {
 	s.handleCommand(t, CodeSuccess, ".", "skeema push")
 	s.dbExec(t, "product", "DROP TABLE `problems`")
 	s.dbExec(t, "product", withoutClauses)
-	s.dbExec(t, "product", "ALTER TABLE `problems` DROP INDEX `idx2`")
+	s.dbExec(t, "product", "ALTER TABLE `problems` DROP KEY `idx2`")
 	writeFile(t, "mydb/product/problems.sql", withClauses)
 	s.handleCommand(t, CodeSuccess, ".", "skeema push")
 }

--- a/skeema_cmd_test.go
+++ b/skeema_cmd_test.go
@@ -296,17 +296,6 @@ func (s *SkeemaIntegrationSuite) TestDiffHandler(t *testing.T) {
 			t.Fatalf("Unable to delete diff-brief.out: %s", err)
 		}
 	}
-
-	// Confirm --verify not tripped up by unexpected index reordering
-	contents := readFile(t, "mydb/product/posts.sql")
-	lines := make([]string, 6)
-	for n := range lines {
-		lines[n] = fmt.Sprintf("KEY `idxnew_%d` (created_at)", n)
-	}
-	replacement := fmt.Sprintf("),\n  %s\n", strings.Join(lines, ",\n  "))
-	contents = strings.Replace(contents, ")\n", replacement, 1)
-	writeFile(t, "mydb/product/posts.sql", contents)
-	s.handleCommand(t, CodeDifferencesFound, ".", "skeema diff --verify")
 }
 
 func (s *SkeemaIntegrationSuite) TestPushHandler(t *testing.T) {
@@ -386,6 +375,51 @@ func (s *SkeemaIntegrationSuite) TestPushHandler(t *testing.T) {
 	s.assertMissing(t, "product", "comments", "foo")
 	s.assertMissing(t, "product", "users", "foo")
 	s.assertExists(t, "bonus", "table2", "")
+}
+
+func (s *SkeemaIntegrationSuite) TestIndexOrdering(t *testing.T) {
+	s.handleCommand(t, CodeSuccess, ".", "skeema init --dir mydb -h %s -P %d", s.d.Instance.Host, s.d.Instance.Port)
+
+	// Add 6 new redundant indexes to posts.sql. Place them before the existing
+	// secondary index.
+	contentsOrig := readFile(t, "mydb/product/posts.sql")
+	lines := make([]string, 6)
+	for n := range lines {
+		lines[n] = fmt.Sprintf("KEY `idxnew_%d` (`created_at`)", n)
+	}
+	joinedLines := strings.Join(lines, ",\n  ")
+	contentsIndexesFirst := strings.Replace(contentsOrig, "PRIMARY KEY (`id`),\n", fmt.Sprintf("PRIMARY KEY (`id`),\n  %s,\n", joinedLines), 1)
+	writeFile(t, "mydb/product/posts.sql", contentsIndexesFirst)
+
+	// push should add the indexes, and afterwards diff should report no
+	// differences, even though the index order in the file differs from what is
+	// in mysql
+	s.handleCommand(t, CodeSuccess, "", "skeema push")
+	s.handleCommand(t, CodeSuccess, "", "skeema diff")
+
+	// however, diff --exact-match can see the differences
+	s.handleCommand(t, CodeDifferencesFound, "", "skeema diff --exact-match")
+
+	// pull should re-write the file such that the indexes are now last, just like
+	// what's actually in mysql
+	s.handleCommand(t, CodeSuccess, "", "skeema pull")
+	contentsIndexesLast := strings.Replace(contentsOrig, ")\n", fmt.Sprintf("),\n  %s\n", joinedLines), 1)
+	if fileContents := readFile(t, "mydb/product/posts.sql"); fileContents == contentsIndexesFirst {
+		t.Error("Expected skeema pull to rewrite mydb/product/posts.sql to put indexes last, but file remained unchanged")
+	} else if fileContents != contentsIndexesLast {
+		t.Errorf("Expected skeema pull to rewrite mydb/product/posts.sql to put indexes last, but it did something else entirely. Contents:\n%s\nExpected:\n%s\n", fileContents, contentsIndexesLast)
+	}
+
+	// Edit posts.sql to put the new indexes first again, and ensure
+	// push --exact-match actually reorders them
+	writeFile(t, "mydb/product/posts.sql", contentsIndexesFirst)
+	s.handleCommand(t, CodeSuccess, "", "skeema push --exact-match --alter-algorithm=COPY")
+	s.handleCommand(t, CodeSuccess, "", "skeema diff")
+	s.handleCommand(t, CodeSuccess, "", "skeema diff --exact-match")
+	s.handleCommand(t, CodeSuccess, "", "skeema pull")
+	if fileContents := readFile(t, "mydb/product/posts.sql"); fileContents != contentsIndexesFirst {
+		t.Errorf("Expected skeema pull to have no effect at this point, but instead file now looks like this:\n%s", fileContents)
+	}
 }
 
 func (s *SkeemaIntegrationSuite) TestAutoInc(t *testing.T) {

--- a/target.go
+++ b/target.go
@@ -254,7 +254,10 @@ func (t *Target) verifyDiff(diff *tengo.SchemaDiff) (err error) {
 		return fmt.Errorf("verifyDiff: cannot connect to %s: %s", t.Instance, err)
 	}
 	mods := tengo.StatementModifiers{
-		NextAutoInc: tengo.NextAutoIncIgnore,
+		NextAutoInc:      tengo.NextAutoIncIgnore,
+		StrictIndexOrder: true,   // needed since we must get the SHOW CREATE TABLEs to match
+		AllowUnsafe:      true,   // needed since we're just running against the temp schema
+		AlgorithmClause:  "COPY", // needed to avoid having MySQL ignore index changes that are simply reordered
 	}
 
 	// Iterate over the ALTER-type TableDiffs in the SchemaDiff and index by table

--- a/vendor/github.com/skeema/tengo/Gopkg.toml
+++ b/vendor/github.com/skeema/tengo/Gopkg.toml
@@ -30,8 +30,8 @@
   name = "github.com/VividCortex/mysqlerr"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/fsouza/go-dockerclient"
+  version = "1.2.1"
 
 [[constraint]]
   name = "github.com/go-sql-driver/mysql"

--- a/vendor/github.com/skeema/tengo/alterclause.go
+++ b/vendor/github.com/skeema/tengo/alterclause.go
@@ -9,7 +9,7 @@ import (
 
 // TableAlterClause interface represents a specific single-element difference
 // between two tables. Structs satisfying this interface can generate an ALTER
-// TABLE clause, such as ADD COLUMN, MODIFY COLUMN, ADD INDEX, etc.
+// TABLE clause, such as ADD COLUMN, MODIFY COLUMN, ADD KEY, etc.
 type TableAlterClause interface {
 	Clause() string
 	Unsafe() bool
@@ -71,15 +71,15 @@ func (dc DropColumn) Unsafe() bool {
 
 ///// AddIndex /////////////////////////////////////////////////////////////////
 
-// AddIndex represents a new index that is present on the right-side ("to")
-// schema version of the table, but not the left-side ("from") version. It
-// satisfies the TableAlterClause interface.
+// AddIndex represents an index that is present on the right-side ("to")
+// schema version of the table, but was not identically present on the left-
+// side ("from") version. It satisfies the TableAlterClause interface.
 type AddIndex struct {
 	Table *Table
 	Index *Index
 }
 
-// Clause returns an ADD INDEX clause of an ALTER TABLE statement.
+// Clause returns an ADD KEY clause of an ALTER TABLE statement.
 func (ai AddIndex) Clause() string {
 	return fmt.Sprintf("ADD %s", ai.Index.Definition())
 }
@@ -93,19 +93,19 @@ func (ai AddIndex) Unsafe() bool {
 ///// DropIndex ////////////////////////////////////////////////////////////////
 
 // DropIndex represents an index that was present on the left-side ("from")
-// schema version of the table, but not the right-side ("to") version. It
-// satisfies the TableAlterClause interface.
+// schema version of the table, but not identically present the right-side
+// ("to") version. It satisfies the TableAlterClause interface.
 type DropIndex struct {
 	Table *Table
 	Index *Index
 }
 
-// Clause returns a DROP INDEX clause of an ALTER TABLE statement.
+// Clause returns a DROP KEY clause of an ALTER TABLE statement.
 func (di DropIndex) Clause() string {
 	if di.Index.PrimaryKey {
 		return "DROP PRIMARY KEY"
 	}
-	return fmt.Sprintf("DROP INDEX %s", EscapeIdentifier(di.Index.Name))
+	return fmt.Sprintf("DROP KEY %s", EscapeIdentifier(di.Index.Name))
 }
 
 // Unsafe returns true if this clause is potentially destructive of data.

--- a/vendor/github.com/skeema/tengo/diff.go
+++ b/vendor/github.com/skeema/tengo/diff.go
@@ -28,11 +28,12 @@ const (
 // for a particular table, and/or generate errors if certain clauses are
 // present.
 type StatementModifiers struct {
-	NextAutoInc     NextAutoIncMode // How to handle differences in next-auto-inc values
-	AllowUnsafe     bool            // Whether to allow potentially-destructive DDL (drop table, drop column, modify col type, etc)
-	LockClause      string          // Include a LOCK=[value] clause in generated ALTER TABLE
-	AlgorithmClause string          // Include an ALGORITHM=[value] clause in generated ALTER TABLE
-	IgnoreTable     *regexp.Regexp  // Generate blank DDL if table name matches this regexp
+	NextAutoInc      NextAutoIncMode // How to handle differences in next-auto-inc values
+	AllowUnsafe      bool            // Whether to allow potentially-destructive DDL (drop table, drop column, modify col type, etc)
+	LockClause       string          // Include a LOCK=[value] clause in generated ALTER TABLE
+	AlgorithmClause  string          // Include an ALGORITHM=[value] clause in generated ALTER TABLE
+	IgnoreTable      *regexp.Regexp  // Generate blank DDL if table name matches this regexp
+	StrictIndexOrder bool            // If true, maintain index order even in cases where there is no functional difference
 }
 
 // SchemaDiff stores a set of differences between two database schemas.
@@ -338,15 +339,44 @@ func (td *TableDiff) alterStatement(mods StatementModifiers) (string, error) {
 		}
 	}
 
+	// Ignore index repositioning, unless StrictIndexOrder enabled, or unless the
+	// order is actually relevant to the clustered index key
+	trivialIndexMoves := make(map[string]bool)
+	if !mods.StrictIndexOrder && td.To.ClusteredIndexKey() == td.To.PrimaryKey {
+		// Iterate through the clauses to find cases where we drop an index and then
+		// later re-add the exact same index. (Note that the drop will *always* come
+		// before the subsequent re-add in td.alterClauses in this case.)
+		droppedIndexes := make(map[string]*Index)
+		for _, clause := range td.alterClauses {
+			switch clause := clause.(type) {
+			case DropIndex:
+				droppedIndexes[clause.Index.Name] = clause.Index
+			case AddIndex:
+				if index, dropped := droppedIndexes[clause.Index.Name]; dropped && index.Equals(clause.Index) {
+					trivialIndexMoves[clause.Index.Name] = true
+				}
+			}
+		}
+	}
+
 	clauseStrings := make([]string, 0, len(td.alterClauses))
 	var err error
 	for _, clause := range td.alterClauses {
-		if clause, ok := clause.(ChangeAutoIncrement); ok {
+		switch clause := clause.(type) {
+		case ChangeAutoIncrement:
 			if mods.NextAutoInc == NextAutoIncIgnore {
 				continue
 			} else if mods.NextAutoInc == NextAutoIncIfIncreased && clause.OldNextAutoIncrement >= clause.NewNextAutoIncrement {
 				continue
 			} else if mods.NextAutoInc == NextAutoIncIfAlready && clause.OldNextAutoIncrement <= 1 {
+				continue
+			}
+		case DropIndex:
+			if trivialIndexMoves[clause.Index.Name] {
+				continue
+			}
+		case AddIndex:
+			if trivialIndexMoves[clause.Index.Name] {
 				continue
 			}
 		}


### PR DESCRIPTION
Previously, when a table had multiple secondary indexes, Skeema did not handle attempts to change the order of these indexes in the table definition, or attempts to insert new indexes "before" other existing ones. For InnoDB tables, this is usually just a cosmetic change -- secondary index order only affects tables that have no primary key but multiple unique indexes over non-nullable columns, which is a rare edge case. But despite being cosmetic, inability to reorder indexes was previously breaking Skeema's `--verify` option, due to the output of `SHOW CREATE TABLE` not exactly matching Skeema's expectation.

This PR gives Skeema the ability to understand index ordering changes without --verify breaking. By default, Skeema will still nonetheless ignore such changes (in terms of its generated `ALTER TABLE` expressions), as they are cosmetic and may result in slower `ALTER TABLE` execution. But if a user truly wants to reorder indexes or position a new index anyway, this PR adds a new option `--exact-match` which will cause Skeema to include the correct operations in its generated `ALTER TABLE`s.

Note that in many cases, MySQL *also* ignores these cosmetic attempts to reorder indexes, unless `ALGORITHM=COPY` is used. This can be accomplished in Skeema by using `--alter-algorithm=COPY` along with `--exact-match`. This may result in much slower `ALTER TABLE` execution for large tables, which is why it is not enabled by default.

Fixes #29.