### PR TITLE
Options to use local Docker for temporary schema

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -143,16 +143,16 @@
   version = "v1.0.5"
 
 [[projects]]
+  branch = "master"
   name = "github.com/skeema/mybase"
   packages = ["."]
-  revision = "73745fdcdd16b049ba64a4a7268ca046ced49374"
-  version = "v1.0.3"
+  revision = "d137646a814391b401bb3f295d9a33c81ec2653e"
 
 [[projects]]
-  branch = "master"
   name = "github.com/skeema/tengo"
   packages = ["."]
-  revision = "c597ea74d56aa7693cb1e0576ab6746a6ba3b39f"
+  revision = "2730bfe6926d41a7184e5120d4d902ae21cb9c48"
+  version = "v0.8.8"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -152,7 +152,7 @@
   branch = "master"
   name = "github.com/skeema/tengo"
   packages = ["."]
-  revision = "8e41b861ce69ff416c875262e057c5f2a6d365a7"
+  revision = "c597ea74d56aa7693cb1e0576ab6746a6ba3b39f"
 
 [[projects]]
   branch = "master"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![code coverage](https://img.shields.io/coveralls/skeema/skeema.svg)](https://coveralls.io/r/skeema/skeema)
 [![latest release](https://img.shields.io/github/release/skeema/skeema.svg)](https://github.com/skeema/skeema/releases)
 
-Skeema is a tool for managing MySQL tables and schema changes. It provides a CLI tool allowing you to:
+Skeema is a tool for managing MySQL tables and schema changes in a declarative fashion using pure SQL. It provides a CLI tool allowing you to:
 
 * Export CREATE TABLE statements to the filesystem, for tracking in a repo (git, hg, svn, etc)
 * Diff changes in the schema repo against live DBs to automatically generate DDL
-* Manage multiple environments (dev, staging, prod) and keep them in sync with ease
+* Manage multiple environments (e.g. dev, staging, prod) and keep them in sync with ease
 * Configure use of online schema change tools, such as pt-online-schema-change, for performing ALTERs
-* Convert non-online migrations from Rails, Django, etc into online schema changes in production
+* Convert non-online migrations from frameworks like Rails or Django into online schema changes in production
 
 Skeema supports a pull-request-based workflow for schema change submission, review, and execution. This permits your team to manage schema changes in exactly the same way as you manage code changes.
 
@@ -37,7 +37,7 @@ To download, build from master, and install (or upgrade) Skeema, run:
 
 ## Status
 
-Skeema is generally available, having reached v1 release milestone in July 2018. Prior to that, it was in public beta since October 2016.
+Skeema is generally available, having reached the v1 release milestone in July 2018. Prior to that, it was in public beta since October 2016.
 
 The `skeema` binary is supported on macOS and Linux. For now, it cannot be compiled on Windows.
 

--- a/applier/target.go
+++ b/applier/target.go
@@ -131,10 +131,14 @@ func targetsForIdealSchema(idealSchema *fs.IdealSchema, dir *fs.Dir, instances [
 		return nil, len(instances)
 	}
 	for _, stmtErr := range statementErrors {
-		log.Errorf("%s: %s", stmtErr.Location(), stmtErr.Err)
+		log.Error(stmtErr.Error())
 	}
 	if len(statementErrors) > 0 {
-		log.Warnf("Skipping %s due to %d SQL errors", dir, len(statementErrors))
+		noun := "errors"
+		if len(statementErrors) == 1 {
+			noun = "error"
+		}
+		log.Warnf("Skipping %s due to %d SQL %s", dir, len(statementErrors), noun)
 		return nil, len(instances)
 	}
 

--- a/applier/target.go
+++ b/applier/target.go
@@ -117,12 +117,15 @@ func targetsForIdealSchema(idealSchema *fs.IdealSchema, dir *fs.Dir, instances [
 	// workspace
 	opts := workspace.Options{
 		Type:                workspace.TypeTempSchema,
+		CleanupAction:       workspace.CleanupActionDrop,
 		Instance:            instances[0],
 		SchemaName:          dir.Config.Get("temp-schema"),
-		KeepSchema:          dir.Config.GetBool("reuse-temp-schema"),
 		DefaultCharacterSet: dir.Config.Get("default-character-set"),
 		DefaultCollation:    dir.Config.Get("default-collation"),
 		LockWaitTimeout:     30 * time.Second,
+	}
+	if dir.Config.GetBool("reuse-temp-schema") {
+		opts.CleanupAction = workspace.CleanupActionNone
 	}
 	fsSchema, tableErrors, err := workspace.MaterializeIdealSchema(idealSchema, opts)
 	if err != nil {

--- a/applier/target.go
+++ b/applier/target.go
@@ -1,8 +1,6 @@
 package applier
 
 import (
-	"time"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/skeema/skeema/fs"
 	"github.com/skeema/skeema/workspace"
@@ -115,15 +113,10 @@ func targetsForLogicalSchema(logicalSchema *fs.LogicalSchema, dir *fs.Dir, insta
 
 	// Obtain a *tengo.Schema representation of the dir's *.sql files from a
 	// workspace
-	opts := workspace.Options{
-		Type:            workspace.TypeTempSchema,
-		CleanupAction:   workspace.CleanupActionDrop,
-		Instance:        instances[0],
-		SchemaName:      dir.Config.Get("temp-schema"),
-		LockWaitTimeout: 30 * time.Second,
-	}
-	if dir.Config.GetBool("reuse-temp-schema") {
-		opts.CleanupAction = workspace.CleanupActionNone
+	opts, err := workspace.OptionsForDir(dir, instances[0])
+	if err != nil {
+		log.Warnf("Skipping %s: %s\n", dir, err)
+		return nil, len(instances)
 	}
 	fsSchema, statementErrors, err := workspace.ExecLogicalSchema(logicalSchema, opts)
 	if err != nil {

--- a/applier/target_test.go
+++ b/applier/target_test.go
@@ -63,6 +63,13 @@ func (s ApplierIntegrationSuite) TestTargetsForDirSimple(t *testing.T) {
 		t.Fatalf("Unexpected result from TargetsForDir: %+v, %d", targets, skipCount)
 	}
 
+	// Test with invalid workspace option: should return 0 targets, 2 skipped
+	dir = getDir(t, "../testdata/applier/simple", "--workspace=invalid-option")
+	targets, skipCount = TargetsForDir(dir, 1)
+	if len(targets) != 0 || skipCount != 2 {
+		t.Fatalf("Unexpected result from TargetsForDir: %+v, %d", targets, skipCount)
+	}
+
 	// Test with sufficient maxDepth, but empty instance list: expect 0 targets, 0 skipped
 	setupHostList(t)
 	targets, skipCount = TargetsForDir(dir, 1)

--- a/applier/verifier.go
+++ b/applier/verifier.go
@@ -76,13 +76,14 @@ func VerifyDiff(diff *tengo.SchemaDiff, t *Target) error {
 		opts.CleanupAction = workspace.CleanupActionNone
 	}
 	wsSchema, statementErrors, err := workspace.MaterializeIdealSchema(idealSchema, opts)
-	if err != nil {
-		return err
-	} else if len(statementErrors) > 0 {
-		return statementErrors[0]
+	if err == nil && len(statementErrors) > 0 {
+		err = statementErrors[0]
 	}
-	actualTables := wsSchema.TablesByName()
+	if err != nil {
+		return fmt.Errorf("Diff verification failure: %s", err.Error())
+	}
 
+	actualTables := wsSchema.TablesByName()
 	for name, toTable := range expected {
 		expectCreate, _ := tengo.ParseCreateAutoInc(toTable.CreateStatement)
 		actualCreate, _ := tengo.ParseCreateAutoInc(actualTables[name].CreateStatement)

--- a/applier/verifier.go
+++ b/applier/verifier.go
@@ -2,7 +2,6 @@ package applier
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/skeema/skeema/fs"
 	"github.com/skeema/skeema/workspace"
@@ -65,15 +64,9 @@ func VerifyDiff(diff *tengo.SchemaDiff, t *Target) error {
 		}
 	}
 
-	opts := workspace.Options{
-		Type:            workspace.TypeTempSchema,
-		CleanupAction:   workspace.CleanupActionDrop,
-		Instance:        t.Instance,
-		SchemaName:      t.Dir.Config.Get("temp-schema"),
-		LockWaitTimeout: 30 * time.Second,
-	}
-	if t.Dir.Config.GetBool("reuse-temp-schema") {
-		opts.CleanupAction = workspace.CleanupActionNone
+	opts, err := workspace.OptionsForDir(t.Dir, t.Instance)
+	if err != nil {
+		return err
 	}
 	wsSchema, statementErrors, err := workspace.ExecLogicalSchema(logicalSchema, opts)
 	if err == nil && len(statementErrors) > 0 {

--- a/applier/verifier.go
+++ b/applier/verifier.go
@@ -56,12 +56,15 @@ func VerifyDiff(diff *tengo.SchemaDiff, t *Target) error {
 
 	opts := workspace.Options{
 		Type:                workspace.TypeTempSchema,
+		CleanupAction:       workspace.CleanupActionDrop,
 		Instance:            t.Instance,
 		SchemaName:          t.Dir.Config.Get("temp-schema"),
-		KeepSchema:          t.Dir.Config.GetBool("reuse-temp-schema"),
 		DefaultCharacterSet: t.Dir.Config.Get("default-character-set"),
 		DefaultCollation:    t.Dir.Config.Get("default-collation"),
 		LockWaitTimeout:     30 * time.Second,
+	}
+	if t.Dir.Config.GetBool("reuse-temp-schema") {
+		opts.CleanupAction = workspace.CleanupActionNone
 	}
 	wsSchema, err := workspace.StatementsToSchema(statements, opts)
 	if err != nil {

--- a/cmd_lint.go
+++ b/cmd_lint.go
@@ -98,10 +98,10 @@ func lintWalker(dir *fs.Dir, lc *lintCounters, maxDepth int) error {
 		opts.CleanupAction = workspace.CleanupActionNone
 	}
 
-	for _, idealSchema := range dir.IdealSchemas {
-		schema, statementErrors, err := workspace.MaterializeIdealSchema(idealSchema, opts)
+	for _, logicalSchema := range dir.LogicalSchemas {
+		schema, statementErrors, err := workspace.ExecLogicalSchema(logicalSchema, opts)
 		if err != nil {
-			log.Warnf("Skipping schema %s in %s due to error: %s", idealSchema.Name, dir.Path, err)
+			log.Warnf("Skipping schema %s in %s due to error: %s", logicalSchema.Name, dir.Path, err)
 			lc.errCount++
 			continue
 		}
@@ -118,14 +118,14 @@ func lintWalker(dir *fs.Dir, lc *lintCounters, maxDepth int) error {
 				log.Debugf("Skipping table %s because ignore-table='%s'", table.Name, ignoreTable)
 				continue
 			}
-			body, suffix := idealSchema.CreateTables[table.Name].SplitTextBody()
+			body, suffix := logicalSchema.CreateTables[table.Name].SplitTextBody()
 			if table.CreateStatement != body {
-				idealSchema.CreateTables[table.Name].Text = fmt.Sprintf("%s%s", table.CreateStatement, suffix)
-				length, err := idealSchema.CreateTables[table.Name].FromFile.Rewrite()
+				logicalSchema.CreateTables[table.Name].Text = fmt.Sprintf("%s%s", table.CreateStatement, suffix)
+				length, err := logicalSchema.CreateTables[table.Name].FromFile.Rewrite()
 				if err != nil {
-					return fmt.Errorf("Unable to write to %s: %s", idealSchema.CreateTables[table.Name].File, err)
+					return fmt.Errorf("Unable to write to %s: %s", logicalSchema.CreateTables[table.Name].File, err)
 				}
-				log.Infof("Wrote %s (%d bytes) -- updated file to normalize format", idealSchema.CreateTables[table.Name].File, length)
+				log.Infof("Wrote %s (%d bytes) -- updated file to normalize format", logicalSchema.CreateTables[table.Name].File, length)
 				lc.reformatCount++
 			}
 		}

--- a/cmd_lint.go
+++ b/cmd_lint.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/skeema/mybase"
@@ -87,15 +86,9 @@ func lintWalker(dir *fs.Dir, lc *lintCounters, maxDepth int) error {
 	if err != nil {
 		return err
 	}
-	opts := workspace.Options{
-		Type:            workspace.TypeTempSchema,
-		CleanupAction:   workspace.CleanupActionDrop,
-		Instance:        inst,
-		SchemaName:      dir.Config.Get("temp-schema"),
-		LockWaitTimeout: 30 * time.Second,
-	}
-	if dir.Config.GetBool("reuse-temp-schema") {
-		opts.CleanupAction = workspace.CleanupActionNone
+	opts, err := workspace.OptionsForDir(dir, inst)
+	if err != nil {
+		return NewExitValue(CodeBadConfig, err.Error())
 	}
 
 	for _, logicalSchema := range dir.LogicalSchemas {

--- a/cmd_lint.go
+++ b/cmd_lint.go
@@ -89,12 +89,15 @@ func lintWalker(dir *fs.Dir, lc *lintCounters, maxDepth int) error {
 	}
 	opts := workspace.Options{
 		Type:                workspace.TypeTempSchema,
+		CleanupAction:       workspace.CleanupActionDrop,
 		Instance:            inst,
 		SchemaName:          dir.Config.Get("temp-schema"),
-		KeepSchema:          dir.Config.GetBool("reuse-temp-schema"),
 		DefaultCharacterSet: dir.Config.Get("default-character-set"),
 		DefaultCollation:    dir.Config.Get("default-collation"),
 		LockWaitTimeout:     30 * time.Second,
+	}
+	if dir.Config.GetBool("reuse-temp-schema") {
+		opts.CleanupAction = workspace.CleanupActionNone
 	}
 
 	for _, idealSchema := range dir.IdealSchemas {

--- a/cmd_lint.go
+++ b/cmd_lint.go
@@ -110,7 +110,7 @@ func lintWalker(dir *fs.Dir, lc *lintCounters, maxDepth int) error {
 				log.Debugf("Skipping table %s because ignore-table='%s'", stmtErr.TableName, ignoreTable)
 				continue
 			}
-			log.Errorf("%s: %s", stmtErr.Location(), stmtErr.Err)
+			log.Error(stmtErr.Error())
 			lc.sqlErrCount++
 		}
 		for _, table := range schema.Tables {

--- a/cmd_pull.go
+++ b/cmd_pull.go
@@ -254,15 +254,19 @@ func statementModifiersForPull(config *mybase.Config, instance *tengo.Instance, 
 }
 
 func workspaceOptionsForPull(config *mybase.Config, instance *tengo.Instance) workspace.Options {
-	return workspace.Options{
+	opts := workspace.Options{
 		Type:                workspace.TypeTempSchema,
+		CleanupAction:       workspace.CleanupActionDrop,
 		Instance:            instance,
 		SchemaName:          config.Get("temp-schema"),
-		KeepSchema:          config.GetBool("reuse-temp-schema"),
 		DefaultCharacterSet: config.Get("default-character-set"),
 		DefaultCollation:    config.Get("default-collation"),
 		LockWaitTimeout:     30 * time.Second,
 	}
+	if config.GetBool("reuse-temp-schema") {
+		opts.CleanupAction = workspace.CleanupActionNone
+	}
+	return opts
 }
 
 // alteredTablesForPull returns a map whose keys are names of tables that have

--- a/doc/config.md
+++ b/doc/config.md
@@ -1,5 +1,7 @@
 ## Configuration
 
+**This document describes *how* to configure Skeema with options, in general. To view a reference guide of all specific options that exist, please see [options.md](options.md) instead.**
+
 Skeema is configured by setting options. These options may be provided to Skeema via the command-line and/or via option files.
 
 Handling and parsing of options is intentionally designed to be very similar to the MySQL client and server programs.
@@ -14,7 +16,7 @@ Non-boolean options require a value. For example, you cannot provide --host on t
 
 **String** options may be set to any string of 0 or more characters.
 
-**Enum** options behave like string options, except the set of allowed values is restricted. The option reference lists what values are permitted in each case.
+**Enum** options behave like string options, except the set of allowed values is restricted. The option reference lists what values are permitted in each case. Values are case-insensitive.
 
 **Regular expression** options are used for string-matching. The value should be supplied *without* any surrounding delimiter; for example, use `--ignore-schema='^test.*'`, **NOT** `--ignore-schema='/^test.*/'`. To make a match be case-insensitive, put `(?i)` at the beginning of the regex. For example, `--ignore-schema='(?i)^test.*'` will match "TESTING", "Test", "test", etc.
 

--- a/fs/dir.go
+++ b/fs/dir.go
@@ -38,6 +38,7 @@ type IdealSchema struct {
 	CharSet      string
 	Collation    string
 	CreateTables map[string]*Statement // keyed by table name
+	AlterTables  []*Statement          // alterations that are run separately from CreateTables, afterwards
 }
 
 // ParseDir parses the specified directory, including all *.sql files in it,

--- a/fs/dir_test.go
+++ b/fs/dir_test.go
@@ -22,20 +22,20 @@ func TestParseDir(t *testing.T) {
 	if len(dir.IgnoredStatements) > 0 {
 		t.Errorf("Expected 0 IgnoredStatements, instead found %d", len(dir.IgnoredStatements))
 	}
-	if len(dir.IdealSchemas) != 1 {
-		t.Fatalf("Expected 1 IdealSchema; instead found %d", len(dir.IdealSchemas))
+	if len(dir.LogicalSchemas) != 1 {
+		t.Fatalf("Expected 1 LogicalSchema; instead found %d", len(dir.LogicalSchemas))
 	}
-	idealSchema := dir.IdealSchemas[0]
-	if idealSchema.CharSet != "latin1" || idealSchema.Collation != "latin1_swedish_ci" {
-		t.Error("IdealSchema not correctly populated with charset/collation from .skeema file")
+	logicalSchema := dir.LogicalSchemas[0]
+	if logicalSchema.CharSet != "latin1" || logicalSchema.Collation != "latin1_swedish_ci" {
+		t.Error("LogicalSchema not correctly populated with charset/collation from .skeema file")
 	}
 	expectTableNames := []string{"comments", "posts", "subscriptions", "users"}
-	if len(idealSchema.CreateTables) != len(expectTableNames) {
-		t.Errorf("Unexpected table count: found %d, expected %d", len(idealSchema.CreateTables), len(expectTableNames))
+	if len(logicalSchema.CreateTables) != len(expectTableNames) {
+		t.Errorf("Unexpected table count: found %d, expected %d", len(logicalSchema.CreateTables), len(expectTableNames))
 	} else {
 		for _, name := range expectTableNames {
-			if _, ok := idealSchema.CreateTables[name]; !ok {
-				t.Errorf("Did not find key %s in IdealSchema", name)
+			if _, ok := logicalSchema.CreateTables[name]; !ok {
+				t.Errorf("Did not find key %s in LogicalSchema", name)
 			}
 		}
 	}

--- a/fs/statement.go
+++ b/fs/statement.go
@@ -22,6 +22,7 @@ const (
 	StatementTypeNoop                  // entirely whitespace and/or comments
 	StatementTypeUse
 	StatementTypeCreateTable
+	StatementTypeAlterTable
 	// Other types will be added once they are supported by the package
 )
 
@@ -35,7 +36,7 @@ type Statement struct {
 	Text            string
 	DefaultDatabase string // only populated if a StatementTypeUse was encountered
 	Type            StatementType
-	TableName       string // only populated if Type == StatementTypeCreateTable
+	TableName       string // only populated for Types relating to Tables
 	FromFile        *TokenizedSQLFile
 }
 

--- a/fs/statement.go
+++ b/fs/statement.go
@@ -43,11 +43,13 @@ type Statement struct {
 // Location returns the file, line number, and character number where the
 // statement was obtained from
 func (stmt *Statement) Location() string {
-	file := stmt.File
-	if file == "" {
-		file = "unknown"
+	if stmt.File == "" && stmt.LineNo == 0 && stmt.CharNo == 0 {
+		return ""
 	}
-	return fmt.Sprintf("%s:%d:%d", file, stmt.LineNo, stmt.CharNo)
+	if stmt.File == "" {
+		return fmt.Sprintf("unknown:%d:%d", stmt.LineNo, stmt.CharNo)
+	}
+	return fmt.Sprintf("%s:%d:%d", stmt.File, stmt.LineNo, stmt.CharNo)
 }
 
 var reSplitTextBody = regexp.MustCompile(`(\s*;?\s*)$`)

--- a/fs/statement_test.go
+++ b/fs/statement_test.go
@@ -19,6 +19,12 @@ func TestStatementLocation(t *testing.T) {
 	if stmt.Location() != "unknown:123:45" {
 		t.Errorf("Location() returned unexpected result: %s", stmt.Location())
 	}
+
+	// Test blank return if no location-related fields
+	stmt = Statement{}
+	if stmt.Location() != "" {
+		t.Errorf("Location() returned unexpected result: %s", stmt.Location())
+	}
 }
 
 func TestStatementSplitTextBody(t *testing.T) {

--- a/skeema.go
+++ b/skeema.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/skeema/mybase"
 	"github.com/skeema/skeema/util"
+	"github.com/skeema/skeema/workspace"
 )
 
 const rootDesc = `Skeema is a MySQL schema management tool. It allows you to export a database
@@ -15,7 +16,7 @@ schema to the filesystem, and apply online schema changes by modifying files.`
 
 // Globals overridden by GoReleaser's ldflags
 var (
-	version = "1.0.6-dev"
+	version = "1.1.0-dev"
 	commit  = "unknown"
 	date    = "unknown"
 )
@@ -49,7 +50,9 @@ func main() {
 		Exit(NewExitValue(CodeBadConfig, err.Error()))
 	}
 
-	Exit(cfg.HandleCommand())
+	err = cfg.HandleCommand()
+	workspace.Shutdown()
+	Exit(err)
 }
 
 func versionString() string {

--- a/skeema_cmd_test.go
+++ b/skeema_cmd_test.go
@@ -239,6 +239,9 @@ func (s SkeemaIntegrationSuite) TestLintHandler(t *testing.T) {
 	cfg := s.handleCommand(t, CodeSuccess, ".", "skeema lint")
 	s.verifyFiles(t, cfg, "../golden/init")
 
+	// Invalid options should error with CodeBadConfig
+	s.handleCommand(t, CodeBadConfig, ".", "skeema lint --workspace=doesnt-exist")
+
 	// Alter a few files in a way that is still valid SQL, but doesn't match
 	// the database's native format. Lint should rewrite these files and then
 	// return exit code CodeDifferencesFound.
@@ -809,6 +812,9 @@ func (s SkeemaIntegrationSuite) TestReuseTempSchema(t *testing.T) {
 		s.assertExists(t, "verytemp", "", "")
 		s.verifyFiles(t, cfg, "../golden/init")
 	}
+
+	// Invalid workspace option should error
+	s.handleCommand(t, CodeBadConfig, ".", "skeema pull --workspace=doesnt-exist --skip-normalize --reuse-temp-schema --temp-schema=verytemp")
 }
 
 func (s SkeemaIntegrationSuite) TestShardedSchemas(t *testing.T) {

--- a/skeema_test.go
+++ b/skeema_test.go
@@ -241,10 +241,10 @@ func (s *SkeemaIntegrationSuite) verifyFiles(t *testing.T, cfg *mybase.Config, d
 		}
 
 		// Compare parsed CREATE TABLEs
-		if len(a.IdealSchemas) != len(b.IdealSchemas) {
-			t.Errorf("Mismatch between count of parsed ideal schemas: %s=%d vs %s=%d", a, len(a.IdealSchemas), b, len(b.IdealSchemas))
-		} else if len(a.IdealSchemas) > 0 {
-			aCreates, bCreates := a.IdealSchemas[0].CreateTables, b.IdealSchemas[0].CreateTables
+		if len(a.LogicalSchemas) != len(b.LogicalSchemas) {
+			t.Errorf("Mismatch between count of parsed logical schemas: %s=%d vs %s=%d", a, len(a.LogicalSchemas), b, len(b.LogicalSchemas))
+		} else if len(a.LogicalSchemas) > 0 {
+			aCreates, bCreates := a.LogicalSchemas[0].CreateTables, b.LogicalSchemas[0].CreateTables
 			if len(aCreates) != len(bCreates) {
 				t.Errorf("Mismatch in CREATE TABLE count: %s=%d, %s=%d", a, len(aCreates), b, len(bCreates))
 			} else {

--- a/util/config.go
+++ b/util/config.go
@@ -35,8 +35,10 @@ func AddGlobalOptions(cmd *mybase.Command) {
 	cmd.AddOption(mybase.StringOption("host-wrapper", 'H', "", "External bin to shell out to for host lookup; see manual for template vars"))
 	cmd.AddOption(mybase.StringOption("temp-schema", 't', "_skeema_tmp", "Name of temporary schema for intermediate operations, created and dropped each run unless --reuse-temp-schema"))
 	cmd.AddOption(mybase.StringOption("connect-options", 'o', "", "Comma-separated session options to set upon connecting to each database instance"))
+	cmd.AddOption(mybase.StringOption("docker-cleanup", 0, "none", `With --docker, specifies show to clean up containers (valid values: "NONE", "STOP", "DESTROY")`))
 	cmd.AddOption(mybase.BoolOption("reuse-temp-schema", 0, false, "Do not drop temp-schema when done"))
 	cmd.AddOption(mybase.BoolOption("debug", 0, false, "Enable debug logging"))
+	cmd.AddOption(mybase.BoolOption("docker", 0, false, "Use a local Docker container for all intermediate operations"))
 }
 
 // AddGlobalConfigFiles takes the mybase.Config generated from the CLI and adds

--- a/util/config.go
+++ b/util/config.go
@@ -35,10 +35,10 @@ func AddGlobalOptions(cmd *mybase.Command) {
 	cmd.AddOption(mybase.StringOption("host-wrapper", 'H', "", "External bin to shell out to for host lookup; see manual for template vars"))
 	cmd.AddOption(mybase.StringOption("temp-schema", 't', "_skeema_tmp", "Name of temporary schema for intermediate operations, created and dropped each run unless --reuse-temp-schema"))
 	cmd.AddOption(mybase.StringOption("connect-options", 'o', "", "Comma-separated session options to set upon connecting to each database instance"))
-	cmd.AddOption(mybase.StringOption("docker-cleanup", 0, "none", `With --docker, specifies show to clean up containers (valid values: "NONE", "STOP", "DESTROY")`))
+	cmd.AddOption(mybase.StringOption("workspace", 'w', "TEMP-SCHEMA", `Specifies where to run intermediate operations (valid values: "TEMP-SCHEMA", "DOCKER")`))
+	cmd.AddOption(mybase.StringOption("docker-cleanup", 0, "NONE", `With --workspace=docker, specifies show to clean up containers (valid values: "NONE", "STOP", "DESTROY")`))
 	cmd.AddOption(mybase.BoolOption("reuse-temp-schema", 0, false, "Do not drop temp-schema when done"))
 	cmd.AddOption(mybase.BoolOption("debug", 0, false, "Enable debug logging"))
-	cmd.AddOption(mybase.BoolOption("docker", 0, false, "Use a local Docker container for all intermediate operations"))
 }
 
 // AddGlobalConfigFiles takes the mybase.Config generated from the CLI and adds

--- a/vendor/github.com/skeema/mybase/config.go
+++ b/vendor/github.com/skeema/mybase/config.go
@@ -355,11 +355,20 @@ func (cfg *Config) GetIntOrDefault(name string) int {
 func (cfg *Config) GetEnum(name string, allowedValues ...string) (string, error) {
 	value := strings.ToLower(cfg.Get(name))
 	defaultValue, _ := cfg.CLI.Command.OptionValue(name)
-	allowedValues = append(allowedValues, defaultValue)
+	var seenDefaultInAllowed bool
 	for _, allowedVal := range allowedValues {
 		if value == strings.ToLower(allowedVal) {
 			return allowedVal, nil
 		}
+		if strings.ToLower(allowedVal) == strings.ToLower(defaultValue) {
+			seenDefaultInAllowed = true
+		}
+	}
+	if !seenDefaultInAllowed {
+		if value == strings.ToLower(defaultValue) {
+			return defaultValue, nil
+		}
+		allowedValues = append(allowedValues, defaultValue)
 	}
 	for n := range allowedValues {
 		allowedValues[n] = fmt.Sprintf(`"%s"`, allowedValues[n])

--- a/vendor/github.com/skeema/tengo/docker.go
+++ b/vendor/github.com/skeema/tengo/docker.go
@@ -248,7 +248,11 @@ func (di *DockerizedInstance) Port() int {
 // DSN returns a github.com/go-sql-driver/mysql formatted DSN corresponding
 // to its containerized mysql-server instance.
 func (di *DockerizedInstance) DSN() string {
-	return fmt.Sprintf("root:%s@tcp(127.0.0.1:%d)/", di.RootPassword, di.Port())
+	var pass string
+	if di.RootPassword != "" {
+		pass = fmt.Sprintf(":%s", di.RootPassword)
+	}
+	return fmt.Sprintf("root%s@tcp(127.0.0.1:%d)/", pass, di.Port())
 }
 
 func (di *DockerizedInstance) String() string {
@@ -280,11 +284,15 @@ func (di *DockerizedInstance) SourceSQL(filePath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("SourceSQL %s: Unable to open setup file %s: %s", di, filePath, err)
 	}
+	cmd := []string{"mysql", "-tvvv"}
+	if di.RootPassword != "" {
+		cmd = append(cmd, fmt.Sprintf("-p%s", di.RootPassword))
+	}
 	ceopts := docker.CreateExecOptions{
 		AttachStdout: true,
 		AttachStderr: true,
 		AttachStdin:  true,
-		Cmd:          []string{"mysql", "-tvvv", fmt.Sprintf("-p%s", di.RootPassword)},
+		Cmd:          cmd,
 		Container:    di.container.ID,
 	}
 	exec, err := di.Manager.client.CreateExec(ceopts)

--- a/vendor/github.com/skeema/tengo/testing.go
+++ b/vendor/github.com/skeema/tengo/testing.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/go-sql-driver/mysql"
 )
 
 // This file contains public functions and structs designed to make integration
@@ -83,28 +81,4 @@ func SplitEnv(key string) []string {
 		return []string{}
 	}
 	return strings.Split(value, ",")
-}
-
-type filteredLogger struct {
-	logger *log.Logger
-}
-
-func (fl filteredLogger) Print(v ...interface{}) {
-	if len(v) > 0 {
-		if err, ok := v[0].(error); ok && err.Error() == "unexpected EOF" {
-			return
-		}
-	}
-	fl.logger.Print(v...)
-}
-
-// UseFilteredDriverLogger overrides the mysql driver's logger to avoid excessive
-// messages. Currently this just suppresses the driver's "unexpected EOF"
-// output, which occurs when an initial connection is refused or a connection
-// drops early.
-func UseFilteredDriverLogger() {
-	fl := filteredLogger{
-		logger: log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime|log.Lshortfile),
-	}
-	mysql.SetLogger(fl)
 }

--- a/workspace/localdocker.go
+++ b/workspace/localdocker.go
@@ -33,6 +33,7 @@ func NewLocalDocker(opts Options) (ld *LocalDocker, err error) {
 		if dockerClient, err = tengo.NewDockerClient(tengo.DockerClientOptions{}); err != nil {
 			return
 		}
+		tengo.UseFilteredDriverLogger()
 	}
 	ld = &LocalDocker{
 		schemaName: opts.SchemaName,

--- a/workspace/localdocker.go
+++ b/workspace/localdocker.go
@@ -1,0 +1,131 @@
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/skeema/tengo"
+)
+
+// LocalDocker is a Workspace created inside of a Docker container on localhost.
+// The schema is dropped when done interacting with the workspace, but the
+// container may optionally remain running, be stopped, or be destroyed
+// entirely.
+type LocalDocker struct {
+	schemaName  string
+	d           *tengo.DockerizedInstance
+	releaseLock releaseFunc
+}
+
+var seenContainerNames map[string]bool
+
+// NewLocalDocker finds or creates a containerized MySQL instance, creates a
+// temporary schema on it, and returns it.
+func NewLocalDocker(opts Options) (ld *LocalDocker, err error) {
+	if !opts.Flavor.Supported() {
+		return nil, fmt.Errorf("NewLocalDocker: unsupported flavor %s", opts.Flavor)
+	}
+
+	var sandboxer *tengo.DockerSandboxer
+	if sandboxer, err = getSandboxer(opts); err != nil {
+		return
+	}
+
+	ld = &LocalDocker{
+		schemaName: opts.SchemaName,
+	}
+	image := opts.Flavor.String()
+	containerName := fmt.Sprintf("skeema-%s", strings.Replace(image, ":", "-", -1))
+	ld.d, err = sandboxer.GetOrCreateInstance(containerName, image)
+	if err != nil {
+		return nil, err
+	}
+
+	lockName := fmt.Sprintf("skeema.%s", ld.schemaName)
+	if ld.releaseLock, err = getLock(ld.d.Instance, lockName, opts.LockWaitTimeout); err != nil {
+		return nil, fmt.Errorf("Unable to obtain lock on %s: %s", ld.d.Instance, err)
+	}
+	// If this function errors, don't continue to hold the lock
+	defer func() {
+		if err != nil {
+			ld.releaseLock()
+		}
+	}()
+
+	if opts.CleanupAction != CleanupActionNone && !seenContainerNames[containerName] {
+		if opts.CleanupAction == CleanupActionStop {
+			RegisterShutdownFunc(func() {
+				ld.d.Stop()
+			})
+		} else if opts.CleanupAction == CleanupActionDestroy {
+			RegisterShutdownFunc(func() {
+				ld.d.Destroy()
+			})
+		}
+		seenContainerNames[containerName] = true
+	}
+
+	if has, err := ld.d.HasSchema(ld.schemaName); err != nil {
+		return nil, fmt.Errorf("Unable to check for existence of temp schema on %s: %s", ld.d.Instance, err)
+	} else if has {
+		// Attempt to drop any tables already present in schema, but fail if any
+		// of them actually have 1 or more rows
+		if err := ld.d.DropTablesInSchema(ld.schemaName, true); err != nil {
+			return nil, fmt.Errorf("Cannot drop existing temporary schema tables on %s: %s", ld.d.Instance, err)
+		}
+	} else {
+		_, err = ld.d.CreateSchema(ld.schemaName, opts.DefaultCharacterSet, opts.DefaultCollation)
+		if err != nil {
+			return nil, fmt.Errorf("Cannot create temporary schema on %s: %s", ld.d.Instance, err)
+		}
+	}
+	return ld, nil
+}
+
+// ConnectionPool returns a connection pool (*sqlx.DB) to the temporary
+// workspace schema, using the supplied connection params (which may be blank).
+func (ld *LocalDocker) ConnectionPool(params string) (*sqlx.DB, error) {
+	return ld.d.Connect(ld.schemaName, params)
+}
+
+// IntrospectSchema introspects and returns the temporary workspace schema.
+func (ld *LocalDocker) IntrospectSchema() (*tengo.Schema, error) {
+	return ld.d.Schema(ld.schemaName)
+}
+
+// Cleanup drops the temporary schema from the Dockerized instance. If any
+// tables have any rows in the temp schema, the cleanup aborts and an error is
+// returned.
+// Cleanup does not handle stopping or destroying the container. If requested,
+// that is handled by Shutdown() instead, so that containers aren't needlessly
+// created and stopped/destroyed multiple times during a program's execution.
+func (ld *LocalDocker) Cleanup() error {
+	if ld.releaseLock == nil {
+		return errors.New("Cleanup() called multiple times on same LocalDocker")
+	}
+	defer func() {
+		ld.releaseLock()
+		ld.releaseLock = nil
+	}()
+
+	if err := ld.d.DropTablesInSchema(ld.schemaName, true); err != nil {
+		return fmt.Errorf("Cannot drop tables in temporary schema on %s: %s", ld.d.Instance, err)
+	}
+	return nil
+}
+
+var managers map[string]*tengo.DockerSandboxer
+
+func getSandboxer(opts Options) (*tengo.DockerSandboxer, error) {
+	if manager, ok := managers[opts.RootPassword]; ok {
+		return manager, nil
+	}
+	sandboxerOptions := tengo.SandboxerOptions{
+		RootPassword: opts.RootPassword,
+	}
+	var err error
+	managers[opts.RootPassword], err = tengo.NewDockerSandboxer(sandboxerOptions)
+	return managers[opts.RootPassword], err
+}

--- a/workspace/localdocker.go
+++ b/workspace/localdocker.go
@@ -110,8 +110,8 @@ func (ld *LocalDocker) Cleanup() error {
 		ld.releaseLock = nil
 	}()
 
-	if err := ld.d.DropTablesInSchema(ld.schemaName, true); err != nil {
-		return fmt.Errorf("Cannot drop tables in temporary schema on %s: %s", ld.d.Instance, err)
+	if err := ld.d.DropSchema(ld.schemaName, true); err != nil {
+		return fmt.Errorf("Cannot drop temporary schema on %s: %s", ld.d.Instance, err)
 	}
 	return nil
 }
@@ -126,6 +126,9 @@ func getSandboxer(opts Options) (*tengo.DockerSandboxer, error) {
 		RootPassword: opts.RootPassword,
 	}
 	var err error
+	if managers == nil {
+		managers = make(map[string]*tengo.DockerSandboxer)
+	}
 	managers[opts.RootPassword], err = tengo.NewDockerSandboxer(sandboxerOptions)
 	return managers[opts.RootPassword], err
 }

--- a/workspace/localdocker_test.go
+++ b/workspace/localdocker_test.go
@@ -2,7 +2,62 @@ package workspace
 
 import (
 	"testing"
+	"time"
+
+	"github.com/skeema/tengo"
 )
 
 func (s WorkspaceIntegrationSuite) TestLocalDocker(t *testing.T) {
+	opts := Options{
+		Type:                TypeLocalDocker,
+		CleanupAction:       CleanupActionNone,
+		Flavor:              tengo.FlavorUnknown,
+		SchemaName:          "_skeema_tmp",
+		DefaultCharacterSet: "latin1",
+		DefaultCollation:    "latin1_swedish_ci",
+		RootPassword:        "testing",
+		LockWaitTimeout:     100 * time.Millisecond,
+	}
+
+	// FlavorUnknown should result in error
+	if _, err := New(opts); err == nil {
+		t.Fatal("Expected error from FlavorUnknown, but err was nil")
+	}
+
+	// Valid flavor should succeed
+	opts.Flavor = s.d.Flavor()
+	ws, err := New(opts)
+	if err != nil {
+		t.Errorf("Unexpected error from New(): %s", err)
+	}
+	ld := ws.(*LocalDocker)
+	if _, err = New(opts); err == nil {
+		t.Fatal("Expected error from already-locked instance, instead err is nil")
+	}
+	if ld.d == s.d {
+		t.Error("Expected LocalDocker to point to different DockerizedInstance than test suite, but they match")
+	}
+	if has, err := ld.d.HasSchema(opts.SchemaName); !has || err != nil {
+		t.Errorf("Instance does not have expected schema: has=%t err=%s", has, err)
+	}
+	if schema, err := ws.IntrospectSchema(); err != nil || schema.Name != opts.SchemaName || len(schema.Tables) > 0 {
+		t.Errorf("Unexpected result from IntrospectSchema(): %+v / %v", schema, err)
+	}
+	if _, err := ws.ConnectionPool(""); err != nil {
+		t.Errorf("Unexpected error from ConnectionPool(): %s", err)
+	}
+	if err := ws.Cleanup(); err != nil {
+		t.Errorf("Unexpected error from cleanup: %s", err)
+	}
+	if err := ws.Cleanup(); err == nil {
+		t.Error("Expected repeated calls to Cleanup() to error, but err was nil")
+	}
+	if has, err := ld.d.HasSchema(opts.SchemaName); has || err != nil {
+		t.Fatalf("Schema persisted despite Cleanup(): has=%t err=%s", has, err)
+	}
+	Shutdown() // should have no effect, since CleanupActionNone
+	if ok, err := ld.d.CanConnect(); !ok || err != nil {
+		t.Errorf("Unexpected failure from CanConnect(): %t / %v", ok, err)
+	}
+
 }

--- a/workspace/localdocker_test.go
+++ b/workspace/localdocker_test.go
@@ -73,9 +73,8 @@ func (s WorkspaceIntegrationSuite) TestLocalDocker(t *testing.T) {
 		t.Fatalf("Unexpected error from NewLocalDocker(): %s", err)
 	}
 	containerName := ld.d.Name
-	if err := ld.Cleanup(); err != nil {
-		t.Errorf("Unexpected error from cleanup: %s", err)
-	}
+	// Intentionally don't call Cleanup; subsequent tests should still succeed
+	// since lock will inherently be released when container is stopped!
 	Shutdown()
 	if ok, err := ld.d.CanConnect(); ok || err == nil {
 		t.Error("Expected container to be stopped, but CanConnect returned true")

--- a/workspace/localdocker_test.go
+++ b/workspace/localdocker_test.go
@@ -15,7 +15,7 @@ func (s WorkspaceIntegrationSuite) TestLocalDocker(t *testing.T) {
 		SchemaName:          "_skeema_tmp",
 		DefaultCharacterSet: "latin1",
 		DefaultCollation:    "latin1_swedish_ci",
-		RootPassword:        "testing",
+		RootPassword:        "",
 		LockWaitTimeout:     100 * time.Millisecond,
 	}
 
@@ -24,11 +24,18 @@ func (s WorkspaceIntegrationSuite) TestLocalDocker(t *testing.T) {
 		t.Fatal("Expected error from FlavorUnknown, but err was nil")
 	}
 
-	// Valid flavor should succeed
+	// Valid flavor but invalid schema name should error
 	opts.Flavor = s.d.Flavor()
+	opts.SchemaName = "mysql"
+	if _, err := New(opts); err == nil {
+		t.Fatal("Expected error from invalid schema name, but err was nil")
+	}
+	opts.SchemaName = "_skeema_tmp"
+
+	// Test with CleanupActionNone
 	ws, err := New(opts)
 	if err != nil {
-		t.Errorf("Unexpected error from New(): %s", err)
+		t.Fatalf("Unexpected error from New(): %s", err)
 	}
 	ld := ws.(*LocalDocker)
 	if _, err = New(opts); err == nil {
@@ -60,4 +67,44 @@ func (s WorkspaceIntegrationSuite) TestLocalDocker(t *testing.T) {
 		t.Errorf("Unexpected failure from CanConnect(): %t / %v", ok, err)
 	}
 
+	// Test with CleanupActionStop
+	opts.CleanupAction = CleanupActionStop
+	if ld, err = NewLocalDocker(opts); err != nil {
+		t.Fatalf("Unexpected error from NewLocalDocker(): %s", err)
+	}
+	containerName := ld.d.Name
+	if err := ld.Cleanup(); err != nil {
+		t.Errorf("Unexpected error from cleanup: %s", err)
+	}
+	Shutdown()
+	if ok, err := ld.d.CanConnect(); ok || err == nil {
+		t.Error("Expected container to be stopped, but CanConnect returned true")
+	}
+	// Look up the container to prove it exists
+	lookupOpts := tengo.DockerizedInstanceOptions{
+		Name: containerName,
+	}
+	if _, err := dockerClient.GetInstance(lookupOpts); err != nil {
+		t.Errorf("Unable to re-fetch container %s by name: %s", containerName, err)
+	}
+
+	// Test with CleanupActionDestroy
+	opts.CleanupAction = CleanupActionDestroy
+	if ld, err = NewLocalDocker(opts); err != nil {
+		t.Fatalf("Unexpected error from NewLocalDocker(): %s", err)
+	}
+	// Cleanup should fail if a table has rows
+	if _, err := ld.d.SourceSQL("../testdata/tempschema1.sql"); err != nil {
+		t.Fatalf("Unexpected SourceSQL error: %s", err)
+	}
+	if err := ld.Cleanup(); err == nil {
+		t.Error("Expected cleanup error since a table had rows, but err was nil")
+	}
+	Shutdown()
+	if ok, err := ld.d.CanConnect(); ok || err == nil {
+		t.Error("Expected container to be destroyed, but CanConnect returned true")
+	}
+	if _, err := dockerClient.GetInstance(lookupOpts); err == nil {
+		t.Errorf("Expected container %s to be destroyed, but able re-fetch container by name without error", containerName)
+	}
 }

--- a/workspace/localdocker_test.go
+++ b/workspace/localdocker_test.go
@@ -1,0 +1,8 @@
+package workspace
+
+import (
+	"testing"
+)
+
+func (s WorkspaceIntegrationSuite) TestLocalDocker(t *testing.T) {
+}

--- a/workspace/tempschema_test.go
+++ b/workspace/tempschema_test.go
@@ -8,14 +8,13 @@ import (
 func (s WorkspaceIntegrationSuite) TestTempSchema(t *testing.T) {
 	opts := Options{
 		Type:                TypeTempSchema,
+		CleanupAction:       CleanupActionNone,
 		Instance:            s.d.Instance,
 		SchemaName:          "_skeema_tmp",
-		CleanupAction:       CleanupActionNone,
 		DefaultCharacterSet: "latin1",
 		DefaultCollation:    "latin1_swedish_ci",
 		LockWaitTimeout:     100 * time.Millisecond,
 	}
-
 	ts, err := NewTempSchema(opts)
 	if err != nil {
 		t.Fatalf("Unexpected error from NewTempSchema: %s", err)

--- a/workspace/tempschema_test.go
+++ b/workspace/tempschema_test.go
@@ -35,7 +35,7 @@ func (s WorkspaceIntegrationSuite) TestTempSchema(t *testing.T) {
 		t.Error("Expected repeated calls to Cleanup() to error, but err was nil")
 	}
 	if has, err := ts.inst.HasSchema(opts.SchemaName); !has || err != nil {
-		t.Fatalf("Schema did not persist despite KeepSchema: has=%t err=%s", has, err)
+		t.Fatalf("Schema did not persist despite CleanupActionNone: has=%t err=%s", has, err)
 	}
 
 	// Cleanup should fail if a table has rows
@@ -91,7 +91,7 @@ func (s WorkspaceIntegrationSuite) TestTempSchema(t *testing.T) {
 		t.Errorf("Unexpected error from cleanup: %s", err)
 	}
 	if has, err := ts.inst.HasSchema(opts.SchemaName); has || err != nil {
-		t.Fatalf("Schema persisted even without KeepSchema: has=%t err=%s", has, err)
+		t.Fatalf("Schema persisted despite CleanupActionDrop: has=%t err=%s", has, err)
 	}
 
 	// Supplying a nil Instance should error

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -120,7 +120,15 @@ type StatementError struct {
 
 // Error satisfies the builtin error interface.
 func (se *StatementError) Error() string {
-	return se.Err.Error()
+	loc := se.Location()
+	if loc == "" {
+		return fmt.Sprintf("%s [Full SQL: %s]", se.Err.Error(), se.Text)
+	}
+	return fmt.Sprintf("%s: %s", loc, se.Err.Error())
+}
+
+func (se *StatementError) String() string {
+	return se.Error()
 }
 
 // MaterializeIdealSchema converts an IdealSchema to a tengo.Schema. It obtains

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -163,6 +163,7 @@ func Shutdown() {
 	for _, f := range shutdownFuncs {
 		f()
 	}
+	shutdownFuncs = []func(){}
 }
 
 // RegisterShutdownFunc registers a function to be executed by Shutdown.

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -42,6 +42,7 @@ type WorkspaceIntegrationSuite struct {
 }
 
 func (s WorkspaceIntegrationSuite) TestMaterializeIdealSchema(t *testing.T) {
+	// Test with just valid CREATE TABLEs
 	dirPath := "../testdata/golden/init/mydb/product"
 	if major, minor, _ := s.d.Version(); major == 5 && minor == 5 {
 		dirPath = strings.Replace(dirPath, "golden", "golden-mysql55", 1)
@@ -84,6 +85,8 @@ func (s WorkspaceIntegrationSuite) TestMaterializeIdealSchema(t *testing.T) {
 	if len(tableErrors) == 1 {
 		if tableErrors[0].Statement != dir.IdealSchemas[0].AlterTables[0] {
 			t.Error("Unexpected Statement pointed to by StatementError")
+		} else if !strings.Contains(tableErrors[0].String(), dir.IdealSchemas[0].AlterTables[0].Text) {
+			t.Error("StatementError did not contain full SQL of erroring statement")
 		}
 	} else {
 		t.Errorf("Expected one TableError, instead found %d", len(tableErrors))
@@ -104,6 +107,8 @@ func (s WorkspaceIntegrationSuite) TestMaterializeIdealSchema(t *testing.T) {
 		t.Errorf("Expected 1 TableError, instead found %d", len(tableErrors))
 	} else if tableErrors[0].TableName != "posts" {
 		t.Errorf("Expected 1 TableError for table `posts`; instead found it is for table `%s`", tableErrors[0].TableName)
+	} else if !strings.HasPrefix(tableErrors[0].Error(), stmt.Location()) {
+		t.Error("StatementError did not contain the location of the invalid statement")
 	}
 	err = tableErrors[0] // compile-time check of satisfying interface
 	if errorText := err.Error(); errorText == "" {

--- a/workspace/workspace_test.go
+++ b/workspace/workspace_test.go
@@ -140,11 +140,15 @@ func (s *WorkspaceIntegrationSuite) BeforeTest(method string, backend string) er
 }
 
 func (s *WorkspaceIntegrationSuite) getOptionsForDir(dir *fs.Dir) Options {
+	cleanupAction := CleanupActionDrop
+	if dir.Config.GetBool("reuse-temp-schema") {
+		cleanupAction = CleanupActionNone
+	}
 	return Options{
 		Type:                TypeTempSchema,
 		Instance:            s.d.Instance,
 		SchemaName:          dir.Config.Get("temp-schema"),
-		KeepSchema:          dir.Config.GetBool("reuse-temp-schema"),
+		CleanupAction:       cleanupAction,
 		DefaultCharacterSet: dir.Config.Get("default-character-set"),
 		DefaultCollation:    dir.Config.Get("default-collation"),
 		LockWaitTimeout:     100 * time.Millisecond,


### PR DESCRIPTION
### Background
Skeema's behavior does not rely on parsing SQL DDL, as this can be too brittle across various MySQL versions and vendors, which have subtle differences in features and functionality. Instead, Skeema uses metadata reported directly from the database to introspect schemas, using `information_schema` as well as various `SHOW` commands.

In order to accurately introspect the schemas represented in your filesystem's *.sql files, Skeema actually runs the files' `CREATE TABLE` statements in a temporary location, now called a **workspace**. Previously (and still by default), Skeema creates, uses, and then drops a temporary schema on each database it interacts with.

### What's new
This PR adds the ability to instead use a local Docker container for workspace operations. Two new options control this behavior:

* `workspace=docker` tells Skeema to dynamically manage local Docker container(s) for workspace operations, instead of using a temporary schema on each live DB.
* `docker-cleanup` controls how to manage the container lifecycle as Skeema is exiting. The default, `docker-cleanup=none`, leaves containers running so that subsequent invocations of Skeema are faster. Setting `docker-cleanup=stop` stops containers but does not remove them, and `docker-cleanup=destroy` deletes them entirely.

This functionality is especially useful when running Skeema from a different region/datacenter than your database -- for example, running Skeema on your laptop, when your databases are in AWS. Using `workspace=docker` greatly reduces painful network latency in this scenario, especially if you have a large number of tables. See discussion in #25 for background.