### PR TITLE
lint: new options for sanity-checking schemas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 script:
   - $GOPATH/bin/goveralls -v -service=travis-ci
   - go vet ./...
-  - test -z "$(gofmt -s -d {.,fs,workspace,util,applier}/*.go 2>&1)"
+  - test -z "$(gofmt -s -d {.,fs,workspace,util,applier,linter}/*.go 2>&1)"
   - go list -f '{{.Dir}}' ./... | xargs golint -set_exit_status
 
 deploy:

--- a/cmd_lint.go
+++ b/cmd_lint.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/skeema/mybase"
 	"github.com/skeema/skeema/fs"
+	"github.com/skeema/skeema/linter"
 	"github.com/skeema/skeema/workspace"
 	"github.com/skeema/tengo"
 )
@@ -27,11 +27,12 @@ apply config directives from the [staging] section of config files, as well as
 any sectionless directives at the top of the file. If no environment name is
 supplied, the default is "production".
 
-An exit code of 0 will be returned if all files were already formatted properly,
-1 if some files were reformatted but all SQL was valid, or 2+ if at least one
-file had SQL syntax errors or some other error occurred.`
+An exit code of 0 will be returned if no errors or warnings were emitted and all
+files were already formatted properly; 1 if any warnings were emitted and/or
+some files were reformatted; or 2+ if any errors were emitted for any reason.`
 
 	cmd := mybase.NewCommand("lint", summary, desc, LintHandler)
+	linter.AddCommandOptions(cmd)
 	cmd.AddArg("environment", "production", false)
 	CommandSuite.AddSubCommand(cmd)
 }
@@ -43,135 +44,88 @@ func LintHandler(cfg *mybase.Config) error {
 		return err
 	}
 
-	lc := &lintCounters{}
-	if err = lintWalker(dir, lc, 5); err != nil {
-		return err
-	}
-	return lc.exitValue()
-}
-
-type lintCounters struct {
-	errCount      int
-	sqlErrCount   int
-	reformatCount int
-}
-
-func (lc *lintCounters) exitValue() error {
-	var plural string
-	if lc.errCount > 1 || (lc.errCount == 0 && lc.sqlErrCount > 1) {
-		plural = "s"
-	}
+	result := lintWalker(dir, 5)
 	switch {
-	case lc.errCount > 0:
-		return NewExitValue(CodeFatalError, "Skipped %d operation%s due to error%s", lc.errCount, plural, plural)
-	case lc.sqlErrCount > 0:
-		return NewExitValue(CodeFatalError, "Found syntax error%s in %d SQL file%s", plural, lc.sqlErrCount, plural)
-	case lc.reformatCount > 0:
+	case len(result.Exceptions) > 0:
+		exitCode := CodeFatalError
+		for _, err := range result.Exceptions {
+			if _, ok := err.(linter.ConfigError); ok {
+				exitCode = CodeBadConfig
+			}
+		}
+		return NewExitValue(exitCode, "Skipped %d operations due to fatal errors", len(result.Exceptions))
+	case len(result.Errors) > 0:
+		return NewExitValue(CodeFatalError, "Found %d errors", len(result.Errors))
+	case len(result.Warnings) > 0:
+		return NewExitValue(CodeDifferencesFound, "Found %d warnings", len(result.Warnings))
+	case len(result.FormatNotices) > 0:
 		return NewExitValue(CodeDifferencesFound, "")
 	}
 	return nil
 }
 
-func lintWalker(dir *fs.Dir, lc *lintCounters, maxDepth int) error {
+func lintWalker(dir *fs.Dir, maxDepth int) (result *linter.Result) {
 	log.Infof("Linting %s", dir)
 	if len(dir.IgnoredStatements) > 0 {
 		log.Warnf("Ignoring %d unsupported or unparseable statements found in this directory's *.sql files", len(dir.IgnoredStatements))
 	}
 
-	ignoreTable, err := dir.Config.GetRegexp("ignore-table")
-	if err != nil {
-		return NewExitValue(CodeBadConfig, err.Error())
-	}
-
 	// Connect to first defined instance, unless configured to use local Docker
 	var inst *tengo.Instance
 	if wsType, _ := dir.Config.GetEnum("workspace", "temp-schema", "docker"); wsType != "docker" || !dir.Config.Changed("flavor") {
+		var err error
 		if inst, err = dir.FirstInstance(); err != nil {
-			return err
+			result = linter.BadConfigResult(err)
 		}
 	}
-
 	opts, err := workspace.OptionsForDir(dir, inst)
 	if err != nil {
-		return NewExitValue(CodeBadConfig, err.Error())
+		result = linter.BadConfigResult(err)
 	}
 
-	for _, logicalSchema := range dir.LogicalSchemas {
-		// ignore-schema is handled relatively simplistically here: skip dir entirely
-		// if any literal schema name matches the pattern, but don't bother
-		// interpretting schema=`shellout` or schema=*, which require an instance.
-		ignoreSchema, err := dir.Config.GetRegexp("ignore-schema")
+	if result == nil {
+		result = linter.LintDir(dir, opts)
+	}
+	for _, err := range result.Exceptions {
+		log.Error(fmt.Errorf("Skipping schema in %s due to error: %s", dir.RelPath(), err))
+	}
+	for _, annotation := range result.Errors {
+		log.Error(annotation.MessageWithLocation())
+	}
+	for _, annotation := range result.Warnings {
+		log.Warning(annotation.MessageWithLocation())
+	}
+	for _, annotation := range result.FormatNotices {
+		annotation.Statement.Text = annotation.Message
+		length, err := annotation.Statement.FromFile.Rewrite()
 		if err != nil {
-			return NewExitValue(CodeBadConfig, err.Error())
-		} else if ignoreSchema != nil {
-			var foundIgnoredName bool
-			for _, schemaName := range dir.Config.GetSlice("schema", ',', true) {
-				if ignoreSchema.MatchString(schemaName) {
-					foundIgnoredName = true
-				}
-			}
-			if foundIgnoredName {
-				log.Warnf("Skipping schema in %s because ignore-schema='%s'", dir.Path, ignoreSchema)
-				break
-			}
+			writeErr := fmt.Errorf("Unable to write to %s: %s", annotation.Statement.File, err)
+			log.Error(writeErr.Error())
+			result.Exceptions = append(result.Exceptions, writeErr)
+		} else {
+			log.Infof("Wrote %s (%d bytes) -- updated file to normalize format", annotation.Statement.File, length)
 		}
-
-		// Convert the logical schema from the filesystem into a real schema, using a
-		// workspace
-		schema, statementErrors, err := workspace.ExecLogicalSchema(logicalSchema, opts)
-		if err != nil {
-			log.Errorf("Skipping schema in %s due to error: %s", dir.Path, err)
-			lc.errCount++
-			continue
-		}
-
-		// Log and count each errored statement, unless the statement was a CREATE
-		// TABLE and the table name matches ignore-table
-		for _, stmtErr := range statementErrors {
-			if stmtErr.ObjectType == tengo.ObjectTypeTable && ignoreTable != nil && ignoreTable.MatchString(stmtErr.ObjectName) {
-				log.Debugf("Skipping %s because ignore-table='%s'", stmtErr.ObjectKey(), ignoreTable)
-				continue
-			}
-			log.Error(stmtErr.Error())
-			lc.sqlErrCount++
-		}
-
-		// Compare each canonical CREATE in the real schema to each CREATE statement
-		// from the filesystem. In cases where they differ, rewrite the file using
-		// the canonical version from the DB.
-		for key, instCreateText := range schema.ObjectDefinitions() {
-			if key.Type == tengo.ObjectTypeTable && ignoreTable != nil && ignoreTable.MatchString(key.Name) {
-				log.Debugf("Skipping %s because ignore-table='%s'", key, ignoreTable)
-				continue
-			}
-			fsStmt := logicalSchema.Creates[key]
-			fsBody, fsSuffix := fsStmt.SplitTextBody()
-			if instCreateText != fsBody {
-				fsStmt.Text = fmt.Sprintf("%s%s", instCreateText, fsSuffix)
-				length, err := fsStmt.FromFile.Rewrite()
-				if err != nil {
-					return fmt.Errorf("Unable to write to %s: %s", fsStmt.File, err)
-				}
-				log.Infof("Wrote %s (%d bytes) -- updated file to normalize format", fsStmt.File, length)
-				lc.reformatCount++
-			}
-		}
-		os.Stderr.WriteString("\n")
+	}
+	for _, dl := range result.DebugLogs {
+		log.Debug(dl)
 	}
 
+	var subdirErr error
 	if subdirs, badCount, err := dir.Subdirs(); err != nil {
-		log.Errorf("Cannot list subdirs of %s: %s", dir, err)
-		lc.errCount++
+		subdirErr = fmt.Errorf("Cannot list subdirs of %s: %s", dir, err)
 	} else if len(subdirs) > 0 && maxDepth <= 0 {
-		log.Warnf("Not walking subdirs of %s: max depth reached", dir)
-		lc.errCount += len(subdirs)
+		subdirErr = fmt.Errorf("Not walking subdirs of %s: max depth reached", dir)
 	} else {
-		lc.errCount += badCount
+		if badCount > 0 {
+			subdirErr = fmt.Errorf("Ignoring %d subdirs of %s with configuration errors", badCount, dir)
+		}
 		for _, sub := range subdirs {
-			if walkErr := lintWalker(sub, lc, maxDepth-1); walkErr != nil {
-				return walkErr
-			}
+			result.Merge(lintWalker(sub, maxDepth-1))
 		}
 	}
-	return nil
+	if subdirErr != nil {
+		log.Error(subdirErr)
+		result.Exceptions = append(result.Exceptions, subdirErr)
+	}
+	return result
 }

--- a/fs/dir.go
+++ b/fs/dir.go
@@ -101,6 +101,21 @@ func (dir *Dir) BaseName() string {
 	return path.Base(dir.Path)
 }
 
+// RelPath attempts to return the directory path relative to the current working
+// directory. If this is not possible to determine, dir.Path will be returned
+// as-is.
+func (dir *Dir) RelPath() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return dir.Path
+	}
+	rel, err := filepath.Rel(wd, dir.Path)
+	if err != nil {
+		return dir.Path
+	}
+	return rel
+}
+
 // Delete unlinks the directory and all files within.
 func (dir *Dir) Delete() error {
 	return os.RemoveAll(dir.Path)

--- a/fs/dir_test.go
+++ b/fs/dir_test.go
@@ -66,6 +66,24 @@ func TestDirBaseName(t *testing.T) {
 	}
 }
 
+func TestDirRelPath(t *testing.T) {
+	dir := getDir(t, "../testdata/golden/init/mydb/product")
+	if rel := dir.RelPath(); rel != "../testdata/golden/init/mydb/product" {
+		t.Errorf("Unexpected rel path: %s", rel)
+	}
+	dir = getDir(t, "./")
+	if rel := dir.RelPath(); rel != "." {
+		t.Errorf("Unexpected rel path: %s", rel)
+	}
+
+	// Force a relative path into dir.Path (shouldn't normally be possible) and
+	// confirm same value is returned
+	dir.Path = "foo/bar"
+	if rel := dir.RelPath(); rel != "foo/bar" {
+		t.Errorf("Unexpected rel path: %s", rel)
+	}
+}
+
 func TestDirSubdirs(t *testing.T) {
 	dir := getDir(t, "../testdata/golden/init/mydb")
 	subs, badCount, err := dir.Subdirs()

--- a/linter/config.go
+++ b/linter/config.go
@@ -1,0 +1,115 @@
+package linter
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/skeema/mybase"
+	"github.com/skeema/skeema/fs"
+	"github.com/skeema/tengo"
+)
+
+// Severity represents different annotation severity levels.
+type Severity string
+
+// Constants enumerating valid severity levels
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// AddCommandOptions adds linting-related mybase options to the supplied
+// mybase.Command.
+func AddCommandOptions(cmd *mybase.Command) {
+	cmd.AddOption(mybase.StringOption("warnings", 0, "bad-charset,bad-engine,no-pk", "Linter problems to display as warnings (non-fatal); see manual for usage"))
+	cmd.AddOption(mybase.StringOption("errors", 0, "", "Linter problems to treat as fatal errors; see manual for usage"))
+	cmd.AddOption(mybase.StringOption("allow-charset", 0, "latin1,utf8mb4", "Whitelist of acceptable character sets"))
+	cmd.AddOption(mybase.StringOption("allow-engine", 0, "innodb", "Whitelist of acceptable storage engines"))
+}
+
+// Options contains parsed settings controlling linter behavior.
+type Options struct {
+	ProblemSeverity map[string]Severity
+	AllowedCharSets []string
+	AllowedEngines  []string
+	IgnoreSchema    *regexp.Regexp
+	IgnoreTable     *regexp.Regexp
+}
+
+// ShouldIgnore returns true if the option configuration indicates the supplied
+// tengo.ObjectKey should be ignored.
+func (opts Options) ShouldIgnore(key tengo.ObjectKey) bool {
+	if key.Type == tengo.ObjectTypeDatabase && opts.IgnoreSchema != nil {
+		return opts.IgnoreSchema.MatchString(key.Name)
+	} else if key.Type == tengo.ObjectTypeTable && opts.IgnoreTable != nil {
+		return opts.IgnoreTable.MatchString(key.Name)
+	}
+	return false
+}
+
+// OptionsForDir returns Options based on the configuration in an fs.Dir,
+// effectively converting between mybase options and linter options.
+func OptionsForDir(dir *fs.Dir) (Options, error) {
+	opts := Options{
+		ProblemSeverity: make(map[string]Severity),
+		AllowedCharSets: dir.Config.GetSlice("allow-charset", ',', true),
+		AllowedEngines:  dir.Config.GetSlice("allow-engine", ',', true),
+	}
+
+	var err error
+	opts.IgnoreSchema, err = dir.Config.GetRegexp("ignore-schema")
+	if err != nil {
+		return Options{}, ConfigError(err.Error())
+	}
+	opts.IgnoreTable, err = dir.Config.GetRegexp("ignore-table")
+	if err != nil {
+		return Options{}, ConfigError(err.Error())
+	}
+
+	// Populate opts.ProblemSeverity from the warnings and errors options (in
+	// that order, so that in case of duplicate entries, errors take precedence).
+	// The values specified in warnings and errors must be valid defined problems.
+	allAllowed := strings.Join(allProblemNames(), ", ")
+	for _, val := range dir.Config.GetSlice("warnings", ',', true) {
+		val = strings.ToLower(val)
+		if !problemExists(val) {
+			return Options{}, ConfigError(fmt.Sprintf("Option warnings must be a comma-separated list including these values: %s", allAllowed))
+		}
+		opts.ProblemSeverity[val] = SeverityWarning
+	}
+	for _, val := range dir.Config.GetSlice("errors", ',', true) {
+		val = strings.ToLower(val)
+		if !problemExists(val) {
+			return Options{}, ConfigError(fmt.Sprintf("Option errors must be a comma-separated list including these values: %s", allAllowed))
+		}
+		opts.ProblemSeverity[val] = SeverityError
+	}
+
+	// For list-based problems, confirm corresponding list is non-empty
+	problemToList := map[string][]string{
+		"bad-charset": opts.AllowedCharSets,
+		"bad-engine":  opts.AllowedEngines,
+	}
+	for problem, listOption := range problemToList {
+		severity, ok := opts.ProblemSeverity[problem]
+		if ok && len(listOption) == 0 {
+			errStr := fmt.Sprintf(
+				"With option %ss=%s, corresponding option %s must be non-empty",
+				string(severity),
+				problem,
+				strings.Replace(problem, "bad-", "allow-", -1))
+			return Options{}, ConfigError(errStr)
+		}
+	}
+
+	return opts, nil
+}
+
+// ConfigError represents a configuration problem encountered at runtime.
+type ConfigError string
+
+// Error satisfies the builtin error interface.
+func (ce ConfigError) Error() string {
+	return string(ce)
+}

--- a/linter/config_test.go
+++ b/linter/config_test.go
@@ -1,0 +1,58 @@
+package linter
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+func TestOptionsForDir(t *testing.T) {
+	dir := getDir(t, "../testdata/linter/validcfg")
+	if opts, err := OptionsForDir(dir); err != nil {
+		t.Errorf("Unexpected error from OptionsForDir: %s", err)
+	} else {
+		expected := Options{
+			ProblemSeverity: map[string]Severity{
+				"no-pk":       SeverityError,
+				"bad-charset": SeverityWarning,
+				"bad-engine":  SeverityWarning,
+			},
+			AllowedCharSets: []string{"utf8mb4"},
+			AllowedEngines:  []string{"innodb", "myisam"},
+			IgnoreSchema:    regexp.MustCompile(`^metadata$`),
+			IgnoreTable:     regexp.MustCompile(`^_`),
+		}
+		if !reflect.DeepEqual(opts, expected) {
+			t.Errorf("OptionsForDir returned %+v, did not match expectation %+v", opts, expected)
+		}
+	}
+
+	// Coverage for error conditions
+	badOptions := []string{
+		"--errors=made-up-problem",
+		"--warnings='bad-charset,made-up-problem,bad-engine'",
+		"--ignore-table=+",
+		"--ignore-schema=+",
+		"--allow-charset=''",
+		"--allow-engine='' --errors=''",
+	}
+	confirmError := func(cliArgs string) {
+		t.Helper()
+		dir := getDir(t, "../testdata/linter/validcfg", cliArgs)
+		if _, err := OptionsForDir(dir); err == nil {
+			t.Errorf("Expected an error from OptionsForDir with CLI %s, but it was nil", cliArgs)
+		} else if _, ok := err.(ConfigError); !ok {
+			t.Errorf("Expected error to be a ConfigError, but instead type is %T", err)
+		}
+	}
+	for _, badOpt := range badOptions {
+		confirmError(badOpt)
+	}
+
+	// Confirm ConfigError implements Error interface and works as expected
+	var err error
+	err = ConfigError("testing ConfigError")
+	if err.Error() != "testing ConfigError" {
+		t.Errorf("ConfigError not behaving as expected")
+	}
+}

--- a/linter/linter.go
+++ b/linter/linter.go
@@ -1,0 +1,159 @@
+// Package linter handles logic around linting schemas and returning results.
+package linter
+
+import (
+	"fmt"
+
+	"github.com/skeema/skeema/fs"
+	"github.com/skeema/skeema/workspace"
+	"github.com/skeema/tengo"
+)
+
+// Annotation is an error, warning, or notice from linting a single SQL
+// statement.
+type Annotation struct {
+	Statement  *fs.Statement
+	LineOffset int
+	Summary    string
+	Message    string
+	Problem    string
+}
+
+// MessageWithLocation prepends statement location information to a.Message,
+// if location information is available. Otherwise, it appends the full SQL
+// statement that the message refers to.
+func (a *Annotation) MessageWithLocation() string {
+	if a.Statement.File == "" || a.Statement.LineNo == 0 {
+		return fmt.Sprintf("%s [Full SQL: %s]", a.Message, a.Statement.Text)
+	}
+	if a.LineOffset == 0 && a.Statement.CharNo > 1 {
+		return fmt.Sprintf("%s:%d:%d: %s", a.Statement.File, a.Statement.LineNo, a.Statement.CharNo, a.Message)
+	}
+	return fmt.Sprintf("%s:%d: %s", a.Statement.File, a.Statement.LineNo+a.LineOffset, a.Message)
+}
+
+// Result is a combined set of linter annotations and/or Golang errors found
+// when linting a directory and its subdirs.
+type Result struct {
+	Errors        []*Annotation // "Errors" in the linting sense, not in the Golang sense
+	Warnings      []*Annotation
+	FormatNotices []*Annotation
+	DebugLogs     []string
+	Exceptions    []error
+}
+
+// Merge combines other into r's value in-place.
+func (r *Result) Merge(other *Result) {
+	if r == nil || other == nil {
+		return
+	}
+	r.Errors = append(r.Errors, other.Errors...)
+	r.Warnings = append(r.Warnings, other.Warnings...)
+	r.FormatNotices = append(r.FormatNotices, other.FormatNotices...)
+	r.DebugLogs = append(r.DebugLogs, other.DebugLogs...)
+	r.Exceptions = append(r.Exceptions, other.Exceptions...)
+}
+
+// BadConfigResult returns a *Result containing a single ConfigError in the
+// Exceptions field. The supplied err will be converted to a ConfigError if it
+// is not already one.
+func BadConfigResult(err error) *Result {
+	if _, ok := err.(ConfigError); !ok {
+		err = ConfigError(err.Error())
+	}
+	return &Result{
+		Exceptions: []error{err},
+	}
+}
+
+// LintDir lints all logical schemas in dir, returning a combined result. Does
+// not recurse into subdirs.
+func LintDir(dir *fs.Dir, wsOpts workspace.Options) *Result {
+	opts, err := OptionsForDir(dir)
+	if err != nil && len(dir.LogicalSchemas) > 0 {
+		return BadConfigResult(err)
+	}
+
+	result := &Result{}
+	for _, logicalSchema := range dir.LogicalSchemas {
+		// ignore-schema is handled relatively simplistically here: skip dir entirely
+		// if any literal schema name matches the pattern, but don't bother
+		// interpretting schema=`shellout` or schema=*, which require an instance.
+		if opts.IgnoreSchema != nil {
+			var foundIgnoredName bool
+			for _, schemaName := range dir.Config.GetSlice("schema", ',', true) {
+				if opts.IgnoreSchema.MatchString(schemaName) {
+					foundIgnoredName = true
+				}
+			}
+			if foundIgnoredName {
+				result.DebugLogs = append(result.DebugLogs, fmt.Sprintf("Skipping schema in %s because ignore-schema='%s'", dir.RelPath(), opts.IgnoreSchema))
+				return result
+			}
+		}
+		_, res := ExecLogicalSchema(logicalSchema, wsOpts, opts)
+		result.Merge(res)
+	}
+	return result
+}
+
+// ExecLogicalSchema is a wrapper around workspace.ExecLogicalSchema. After the
+// tengo.Schema is obtained and introspected, it is also linted. Any errors
+// are captured as part of the *Result.
+func ExecLogicalSchema(logicalSchema *fs.LogicalSchema, wsOpts workspace.Options, opts Options) (*tengo.Schema, *Result) {
+	result := &Result{}
+
+	// Convert the logical schema from the filesystem into a real schema, using a
+	// workspace
+	schema, statementErrors, err := workspace.ExecLogicalSchema(logicalSchema, wsOpts)
+	if err != nil {
+		result.Exceptions = append(result.Exceptions, err)
+		return nil, result
+	}
+	for _, stmtErr := range statementErrors {
+		if opts.ShouldIgnore(stmtErr.ObjectKey()) {
+			result.DebugLogs = append(result.DebugLogs, fmt.Sprintf("Skipping %s because ignore-table='%s'", stmtErr.ObjectKey(), opts.IgnoreTable))
+			continue
+		}
+		result.Errors = append(result.Errors, &Annotation{
+			Statement: stmtErr.Statement,
+			Summary:   "SQL statement returned an error",
+			Message:   stmtErr.Err.Error(),
+		})
+	}
+
+	for problemName, severity := range opts.ProblemSeverity {
+		annotations := problems[problemName](schema, logicalSchema, opts)
+		for _, a := range annotations {
+			a.Problem = problemName
+			if opts.ShouldIgnore(a.Statement.ObjectKey()) {
+				result.DebugLogs = append(result.DebugLogs, fmt.Sprintf("Skipping %s because ignore-table='%s'", a.Statement.ObjectKey(), opts.IgnoreTable))
+			} else if severity == SeverityWarning {
+				result.Warnings = append(result.Warnings, a)
+			} else {
+				result.Errors = append(result.Errors, a)
+			}
+		}
+	}
+
+	// Compare each canonical CREATE in the real schema to each CREATE statement
+	// from the filesystem. In cases where they differ, emit a notice to reformat
+	// the file using the canonical version from the DB.
+	for key, instCreateText := range schema.ObjectDefinitions() {
+		fsStmt := logicalSchema.Creates[key]
+		fsBody, fsSuffix := fsStmt.SplitTextBody()
+		if instCreateText != fsBody {
+			if opts.ShouldIgnore(key) {
+				result.DebugLogs = append(result.DebugLogs, fmt.Sprintf("Skipping %s because ignore-table='%s'", key, opts.IgnoreTable))
+			} else {
+				result.FormatNotices = append(result.FormatNotices, &Annotation{
+					Statement: fsStmt,
+					Summary:   "SQL statement should be reformatted",
+					Message:   fmt.Sprintf("%s%s", instCreateText, fsSuffix),
+				})
+			}
+		}
+	}
+
+	return schema, result
+}

--- a/linter/linter_test.go
+++ b/linter/linter_test.go
@@ -1,0 +1,179 @@
+package linter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skeema/mybase"
+	"github.com/skeema/skeema/fs"
+	"github.com/skeema/skeema/util"
+	"github.com/skeema/skeema/workspace"
+	"github.com/skeema/tengo"
+)
+
+func TestLintDir(t *testing.T) {
+	// This test uses a Dockerized instance; image will be based on first value of
+	// SKEEMA_TEST_IMAGES. Skip test if not set.
+	images := tengo.SplitEnv("SKEEMA_TEST_IMAGES")
+	if len(images) == 0 {
+		t.Skip("SKEEMA_TEST_IMAGES env var is not set")
+	}
+	flavor := tengo.NewFlavor(images[0])
+	wsOpts := workspace.Options{
+		Type:            workspace.TypeLocalDocker,
+		CleanupAction:   workspace.CleanupActionDestroy,
+		Flavor:          flavor,
+		SchemaName:      "_skeema_tmp",
+		LockWaitTimeout: 100 * time.Millisecond,
+	}
+
+	// Suppress packet error output when attempting to connect to a Dockerized
+	// mysql-server which is still starting up
+	tengo.UseFilteredDriverLogger()
+
+	dir := getDir(t, "../testdata/linter/validcfg")
+	result := LintDir(dir, wsOpts)
+	defer workspace.Shutdown()
+
+	// No Exceptions expected with the valid configuration.
+	if len(result.Exceptions) != 0 {
+		t.Fatalf("Expected no fatal exceptions, instead found %d", len(result.Exceptions))
+	}
+
+	// With the configuration in validcfg/.skeema, lack-of-PK is an error, along
+	// with invalid SQL (which is always an error). Other problems are warnings.
+	if len(result.Errors) != 3 {
+		t.Errorf("Expected 3 lint errors, instead found %d", len(result.Errors))
+	} else {
+		for _, a := range result.Errors {
+			switch a.Statement.ObjectName {
+			case "nopk", "multibad":
+				if a.LineOffset != 0 || a.Problem != "no-pk" {
+					t.Errorf("Unexpected annotation values: %+v", a)
+				}
+			case "borked1":
+				if a.LineOffset != 0 || !strings.Contains(a.Message, "Error 1064") {
+					t.Errorf("Unexpected annotation values: %+v", a)
+				}
+			default:
+				t.Errorf("Unexpected linter error for %s: %s", a.Statement.ObjectKey(), a.MessageWithLocation())
+			}
+		}
+	}
+
+	// bad-charset and bad-engine are warnings with this configuration
+	if len(result.Warnings) != 6 {
+		t.Errorf("Expected 6 lint warnings, instead found %d", len(result.Warnings))
+	} else {
+		for _, a := range result.Warnings {
+			switch a.Statement.ObjectName {
+			case "badcsdef":
+				if a.Problem != "bad-charset" || a.LineOffset != 0 {
+					t.Errorf("Unexpected annotation values: %+v", a)
+				}
+			case "badcscol":
+				if a.Problem != "bad-charset" || a.LineOffset != 3 {
+					t.Errorf("Unexpected annotation values: %+v", a)
+				}
+			case "badcsmulti":
+				if a.Problem != "bad-charset" || a.LineOffset != 4 {
+					t.Errorf("Unexpected annotation values: %+v", a)
+				}
+				if !strings.Contains(a.MessageWithLocation(), "badcs.sql:19: ") {
+					t.Errorf("Unexpected value from MessageWithLocation(): %s", a.MessageWithLocation())
+				}
+			case "badengine":
+				if a.Problem != "bad-engine" || a.LineOffset != 4 {
+					t.Errorf("Unexpected annotation values: %+v", a)
+				}
+			case "multibad":
+				if (a.Problem != "bad-engine" && a.Problem != "bad-charset") || a.LineOffset != 3 {
+					t.Errorf("Unexpected annotation values: %+v", a)
+				}
+			default:
+				t.Errorf("Unexpected linter warning for %s: %s", a.Statement.ObjectKey(), a.MessageWithLocation())
+			}
+		}
+	}
+
+	// Expect all valid tables to have formatting problems except for `fine`
+	if len(result.FormatNotices) != 6 {
+		t.Errorf("Expected 6 format notices, instead found %d", len(result.FormatNotices))
+	} else {
+		for _, a := range result.FormatNotices {
+			if a.Statement.ObjectName == "fine" {
+				t.Errorf("Unexpected format notice for table `fine`: %s", a.MessageWithLocation())
+			}
+		}
+	}
+
+	// One debug-log expected, from ignored table _borked2 with SQL syntax error
+	if len(result.DebugLogs) != 1 {
+		t.Errorf("Expected 1 debug log, instead found %d", len(result.DebugLogs))
+	}
+}
+
+func TestLintDirIgnoreSchema(t *testing.T) {
+	// Confirm entire dir is skipped due to matching ignore-schema
+	// (in .skeema, we have schema=whatever, which matches this regexp)
+	dir := getDir(t, "../testdata/linter/validcfg", "--ignore-schema=^what")
+	result := LintDir(dir, workspace.Options{})
+	if len(result.DebugLogs) != 1 {
+		t.Errorf("Expected 1 DebugLog, instead found %d", len(result.DebugLogs))
+	}
+	if len(result.Errors)+len(result.Warnings)+len(result.FormatNotices)+len(result.Exceptions) > 0 {
+		t.Errorf("Unexpected values in result: %+v", result)
+	}
+}
+
+func TestLintDirExceptions(t *testing.T) {
+	// Confirm that errors from OptionsForDir cause LintDir to return a Result with
+	// a single ConfigError exception
+	dir := getDir(t, "../testdata/linter/validcfg", "--ignore-table=+")
+	result := LintDir(dir, workspace.Options{})
+	if len(result.Exceptions) != 1 {
+		t.Errorf("Expected 1 Exception, instead found %d", len(result.Exceptions))
+	} else if _, ok := result.Exceptions[0].(ConfigError); !ok {
+		t.Errorf("Expected Exceptions[0] to be ConfigError, instead found %T", result.Exceptions[0])
+	}
+	if len(result.Errors)+len(result.Warnings)+len(result.FormatNotices)+len(result.DebugLogs) > 0 {
+		t.Errorf("Unexpected values in result: %+v", result)
+	}
+
+	// Confirm that Workspace-related fatals return a Result with a single
+	// exception that is NOT a ConfigError
+	dir = getDir(t, "../testdata/linter/validcfg")
+	wsOpts := workspace.Options{Type: workspace.TypeTempSchema} // intentionally not supplying an Instance, which is required
+	result = LintDir(dir, wsOpts)
+	if len(result.Exceptions) != 1 {
+		t.Errorf("Expected 1 Exception, instead found %d", len(result.Exceptions))
+	} else if _, ok := result.Exceptions[0].(ConfigError); ok {
+		t.Errorf("Expected Exceptions[0] to be ConfigError, instead found %T", result.Exceptions[0])
+	}
+	if len(result.Errors)+len(result.Warnings)+len(result.FormatNotices)+len(result.DebugLogs) > 0 {
+		t.Errorf("Unexpected values in result: %+v", result)
+	}
+}
+
+func getRawConfig(t *testing.T, cliArgs ...string) *mybase.Config {
+	cmd := mybase.NewCommand("lintertest", "", "", nil)
+	util.AddGlobalOptions(cmd)
+	AddCommandOptions(cmd)
+	cmd.AddArg("environment", "production", false)
+	commandLine := "lintertest"
+	if len(cliArgs) > 0 {
+		commandLine = fmt.Sprintf("lintertest %s", strings.Join(cliArgs, " "))
+	}
+	return mybase.ParseFakeCLI(t, cmd, commandLine)
+}
+
+func getDir(t *testing.T, dirPath string, cliArgs ...string) *fs.Dir {
+	t.Helper()
+	dir, err := fs.ParseDir(dirPath, getRawConfig(t, cliArgs...))
+	if err != nil {
+		t.Fatalf("Unexpected error parsing dir %s: %s", dirPath, err)
+	}
+	return dir
+}

--- a/linter/problems.go
+++ b/linter/problems.go
@@ -1,0 +1,152 @@
+package linter
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/skeema/skeema/fs"
+	"github.com/skeema/tengo"
+)
+
+// A Detector function analyzes a schema for a particular problem, returning
+// annotations for cases of the problem found.
+type Detector func(*tengo.Schema, *fs.LogicalSchema, Options) []*Annotation
+
+var problems map[string]Detector
+
+// RegisterProblem adds a new named problem, along with its detector function.
+func RegisterProblem(name string, fn Detector) {
+	problems[name] = fn
+}
+
+func init() {
+	problems = map[string]Detector{
+		"no-pk":       noPKDetector,
+		"bad-charset": badCharsetDetector,
+		"bad-engine":  badEngineDetector,
+	}
+}
+
+func noPKDetector(schema *tengo.Schema, logicalSchema *fs.LogicalSchema, _ Options) []*Annotation {
+	results := make([]*Annotation, 0)
+	for _, table := range schema.Tables {
+		if table.PrimaryKey == nil {
+			key := tengo.ObjectKey{Type: tengo.ObjectTypeTable, Name: table.Name}
+			results = append(results, &Annotation{
+				Statement: logicalSchema.Creates[key],
+				Summary:   "No primary key",
+				Message:   fmt.Sprintf("Table %s does not define a PRIMARY KEY", table.Name),
+			})
+		}
+	}
+	return results
+}
+
+func badCharsetDetector(schema *tengo.Schema, logicalSchema *fs.LogicalSchema, opts Options) []*Annotation {
+	results := make([]*Annotation, 0)
+	for _, table := range schema.Tables {
+		// Check the table's default charset
+		if !isAllowed(table.CharSet, opts.AllowedCharSets) {
+			key := tengo.ObjectKey{Type: tengo.ObjectTypeTable, Name: table.Name}
+			stmt := logicalSchema.Creates[key]
+			re := regexp.MustCompile(fmt.Sprintf(`(?i)(default)?\s*(character\s+set|charset|collate)\s*=?\s*(%s|%s)`, table.CharSet, table.Collation))
+			results = append(results, &Annotation{
+				Statement:  logicalSchema.Creates[key],
+				LineOffset: findLastLineOffset(re, stmt.Text),
+				Summary:    "Character set not permitted",
+				Message:    fmt.Sprintf("Table %s is using default character set %s, which is not listed in option allow-charset", table.Name, table.CharSet),
+			})
+			continue // if a table's default charset isn't allowed, don't generate col-level annotations too
+		}
+
+		// If default charset was ok, now check individual columns
+		for _, col := range table.Columns {
+			if col.CharSet != "" && !isAllowed(col.CharSet, opts.AllowedCharSets) {
+				key := tengo.ObjectKey{Type: tengo.ObjectTypeTable, Name: table.Name}
+				stmt := logicalSchema.Creates[key]
+				re := regexp.MustCompile(fmt.Sprintf(`(?i)(character\s+set|charset|collate)\s*(%s|%s)`, col.CharSet, col.Collation))
+				results = append(results, &Annotation{
+					Statement:  logicalSchema.Creates[key],
+					LineOffset: findFirstLineOffset(re, stmt.Text),
+					Summary:    "Character set not permitted",
+					Message:    fmt.Sprintf("Column %s of table %s is using character set %s, which is not listed in option allow-charset", col.Name, table.Name, table.CharSet),
+				})
+				break // stop after the first disallowed charset col per table
+			}
+		}
+	}
+	return results
+}
+
+func badEngineDetector(schema *tengo.Schema, logicalSchema *fs.LogicalSchema, opts Options) []*Annotation {
+	results := make([]*Annotation, 0)
+	for _, table := range schema.Tables {
+		if !isAllowed(table.Engine, opts.AllowedEngines) {
+			key := tengo.ObjectKey{Type: tengo.ObjectTypeTable, Name: table.Name}
+			stmt := logicalSchema.Creates[key]
+			re := regexp.MustCompile(fmt.Sprintf(`(?i)ENGINE\s*=?\s*%s`, table.Engine))
+			results = append(results, &Annotation{
+				Statement:  stmt,
+				LineOffset: findFirstLineOffset(re, stmt.Text),
+				Summary:    "Storage engine not permitted",
+				Message:    fmt.Sprintf("Table %s is using storage engine %s, which is not listed in option allow-engine", table.Name, table.Engine),
+			})
+		}
+	}
+
+	return results
+}
+
+func problemExists(name string) bool {
+	_, ok := problems[strings.ToLower(name)]
+	return ok
+}
+
+func allProblemNames() []string {
+	result := make([]string, 0, len(problems))
+	for name := range problems {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// isAllowed performs a case-insensitive search for value in allowed, returning
+// true if found.
+func isAllowed(value string, allowed []string) bool {
+	value = strings.ToLower(value)
+	for _, allowedValue := range allowed {
+		if value == strings.ToLower(allowedValue) {
+			return true
+		}
+	}
+	return false
+}
+
+// findFirstLineOffset returns the line offset (i.e. line number starting at 0)
+// for the first match of re within createStatement. If no match occurs, 0 is
+// returned. This may happen often due to createStatement being arbitrarily
+// formatted.
+func findFirstLineOffset(re *regexp.Regexp, createStatement string) int {
+	loc := re.FindStringIndex(createStatement)
+	if loc == nil {
+		return 0
+	}
+	// Count how many newlines occur in createStatement before the match
+	return strings.Count(createStatement[0:loc[0]], "\n")
+}
+
+// findLastLineOffset returns the line offset (i.e. line number starting at 0)
+// for the last match of re within createStatement. If no match occurs, 0 is
+// returned. This may happen often due to createStatement being arbitrarily
+// formatted.
+func findLastLineOffset(re *regexp.Regexp, createStatement string) int {
+	locs := re.FindAllStringIndex(createStatement, -1)
+	if locs == nil {
+		return 0
+	}
+	lastLoc := locs[len(locs)-1]
+	return strings.Count(createStatement[0:lastLoc[0]], "\n")
+}

--- a/linter/problems_test.go
+++ b/linter/problems_test.go
@@ -1,0 +1,71 @@
+package linter
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/skeema/skeema/fs"
+)
+
+func TestProblemExists(t *testing.T) {
+	if !problemExists("NO-PK") {
+		t.Error("Expected no-pk to exist, but it does not")
+	}
+	if problemExists("bad-pk") {
+		t.Error("Expected bad-pk to not exist, but it does")
+	}
+}
+
+func TestAllProblemNames(t *testing.T) {
+	expected := []string{"bad-charset", "bad-engine", "no-pk"}
+	actual := allProblemNames()
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("allProblemNames returned %+v, did not match expectation %+v", actual, expected)
+	}
+
+	// Register a new problem; confirm result comes back in alpha order
+	RegisterProblem("new-prob", nil)
+	defer func() {
+		// Clean up the global state
+		delete(problems, "new-prob")
+	}()
+	expected = []string{"bad-charset", "bad-engine", "new-prob", "no-pk"}
+	actual = allProblemNames()
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("allProblemNames returned %+v, did not match expectation %+v", actual, expected)
+	}
+}
+
+func TestIsAllowed(t *testing.T) {
+	if !isAllowed("NO-pk", allProblemNames()) {
+		t.Error("Unexpected result from isAllowed")
+	}
+	if isAllowed("this does not exist", allProblemNames()) {
+		t.Error("Unexpected result from isAllowed")
+	}
+}
+
+func TestFindFirstLineOffset(t *testing.T) {
+	stmt := fs.ReadTestFile(t, "../testdata/golden/init/mydb/product/posts.sql")
+	re := regexp.MustCompile(`\sDEFAULT\s`)
+	if actual := findFirstLineOffset(re, stmt); actual != 4 {
+		t.Errorf("Expected first line offset to be 4, instead found %d", actual)
+	}
+	re = regexp.MustCompile(`not found in string`)
+	if actual := findFirstLineOffset(re, stmt); actual != 0 {
+		t.Errorf("Expected first line offset to be 0, instead found %d", actual)
+	}
+}
+
+func TestFindLastLineOffset(t *testing.T) {
+	stmt := fs.ReadTestFile(t, "../testdata/golden/init/mydb/product/posts.sql")
+	re := regexp.MustCompile(`\sDEFAULT\s`)
+	if actual := findLastLineOffset(re, stmt); actual != 8 {
+		t.Errorf("Expected last line offset to be 8, instead found %d", actual)
+	}
+	re = regexp.MustCompile(`not found in string`)
+	if actual := findLastLineOffset(re, stmt); actual != 0 {
+		t.Errorf("Expected last line offset to be 0, instead found %d", actual)
+	}
+}

--- a/skeema_cmd_test.go
+++ b/skeema_cmd_test.go
@@ -829,7 +829,7 @@ func (s SkeemaIntegrationSuite) TestNonInnoClauses(t *testing.T) {
 
 	// lint normalizes files to remove the clauses
 	fs.WriteTestFile(t, "mydb/product/problems.sql", withClauses)
-	s.handleCommand(t, CodeDifferencesFound, ".", "skeema lint%s", connectOpts)
+	s.handleCommand(t, CodeDifferencesFound, ".", "skeema lint%s --errors=''", connectOpts)
 	assertFileNormalized()
 
 	// diff views the clauses as no-ops if present in file but not db, or vice versa

--- a/testdata/linter/validcfg/.skeema
+++ b/testdata/linter/validcfg/.skeema
@@ -1,0 +1,14 @@
+# It's ok to specify same problem under both errors and warnings.
+# errors will take precedence, regardless of order in config file.
+errors=no-pk
+warnings=no-pk,bad-charset,bad-engine
+
+allow-charset=utf8mb4
+allow-engine=innodb, myisam
+
+ignore-schema=^metadata$
+ignore-table=^_
+
+schema=whatever
+default-character-set=latin1
+default-collation=latin1_swedish_ci

--- a/testdata/linter/validcfg/badcs.sql
+++ b/testdata/linter/validcfg/badcs.sql
@@ -1,0 +1,19 @@
+# This table uses the schema's default charset of latin1
+CREATE TABLE badcsdef (
+	id int unsigned NOT NULL,
+	name varchar(30),
+	PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE badcscol (
+	id int unsigned NOT NULL,
+	fine varchar(20) COLLATE utf8mb4_swedish_ci,
+	name varchar(30) COLLATE latin1_general_ci,
+	PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE badcsmulti (
+	id int unsigned NOT NULL,
+	name varchar(30) CHARACTER SET latin1,
+	PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/linter/validcfg/badengine.sql
+++ b/testdata/linter/validcfg/badengine.sql
@@ -1,0 +1,5 @@
+CREATE TABLE badengine (
+	id int unsigned NOT NULL,
+	name varchar(30),
+	PRIMARY KEY (id)
+) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4;

--- a/testdata/linter/validcfg/borked.sql
+++ b/testdata/linter/validcfg/borked.sql
@@ -1,0 +1,5 @@
+# Expect this to go in Result.Exceptions
+CREATE TABLE borked1 (lol I dunno just make me a good table pls);
+
+# Expect this to go in Result.DebugLogs due to ignore-table in .skeema
+CREATE TABLE _borked2 (same here ok cool thanks);

--- a/testdata/linter/validcfg/fine.sql
+++ b/testdata/linter/validcfg/fine.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `fine` (
+  `id` int(10) unsigned NOT NULL,
+  `name` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4

--- a/testdata/linter/validcfg/multibad.sql
+++ b/testdata/linter/validcfg/multibad.sql
@@ -1,0 +1,4 @@
+CREATE TABLE multibad (
+	id int unsigned NOT NULL,
+	name varchar(30)
+) ENGINE=MEMORY DEFAULT CHARSET=latin1;

--- a/testdata/linter/validcfg/nopk.sql
+++ b/testdata/linter/validcfg/nopk.sql
@@ -1,0 +1,4 @@
+CREATE TABLE nopk (
+	id int unsigned NOT NULL,
+	name varchar(30)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
Historically, `skeema lint` focused on confirming that all SQL CREATE statements were valid, and reformatting statements to match their canonical form shown by SHOW CREATE. In the future, however, `skeema lint` will become a full-fledged configurable MySQL/MariaDB schema linter. This PR begins this transition by introducing the notion of named "problems" that the linter can detect, and adding several new options to control the linter's behavior.

This PR includes four new options affecting `skeema lint`:

* errors: list of named problems (see below) to trigger a fatal error
* warnings: list of named problems to trigger a non-fatal warning message
* allow-charset: list of character sets to permit without triggering bad-charset problem
* allow-engine: list of storage engines to permit without triggering bad-engine problem

Three simple named problem detectors are included so far:

* no-pk: triggered for tables that have no PRIMARY KEY definition
* bad-charset: triggered for tables using disallowed character sets
* bad-engine: triggered for tables using disallowed storage engines

Future commits will add additional problem detectors, such as the ability to identify redundant indexes, or prohibit the use of particular database features.

A matching CI-like "auto-linter" will soon be entering beta testing. To learn more and sign up for the beta, please visit https://www.skeema.io/blog/2019/01/19/github-api-beta/.

This commit does not yet automatically run the linter prior to diff/push, but that is planned for the near future. Finally, it is likely that the reformatting logic of `skeema lint` will be made optional, and a separate `skeema format` command may be introduced to match the old behavior of `skeema lint`.