### PR TITLE
Stored procedures and functions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -158,10 +158,10 @@
   version = "v1.0.4"
 
 [[projects]]
-  branch = "master"
+  branch = "routines-rebased"
   name = "github.com/skeema/tengo"
   packages = ["."]
-  revision = "5bedfdb68552f4eabc290c0550f9ad1da9414932"
+  revision = "18003d2ca40befe060b52afa2eb241ca732aa5d2"
 
 [[projects]]
   branch = "master"
@@ -198,6 +198,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f219f656309d37caedd501f0fa4be71e51e6c78654174be224f93096325ae586"
+  inputs-digest = "d0d99b9dc2bfd2aff087ddd31650c53aff6cbfda41cef66a5022c53c1fa10cd9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -158,10 +158,10 @@
   version = "v1.0.4"
 
 [[projects]]
-  branch = "routines-rebased"
   name = "github.com/skeema/tengo"
   packages = ["."]
-  revision = "18003d2ca40befe060b52afa2eb241ca732aa5d2"
+  revision = "fe3142ed7edaab9cba00c684230171e2c50c6579"
+  version = "v0.8.14"
 
 [[projects]]
   branch = "master"
@@ -198,6 +198,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d0d99b9dc2bfd2aff087ddd31650c53aff6cbfda41cef66a5022c53c1fa10cd9"
+  inputs-digest = "f219f656309d37caedd501f0fa4be71e51e6c78654174be224f93096325ae586"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,7 +34,7 @@
   name = "github.com/skeema/mybase"
 
 [[constraint]]
-  branch = "routines-rebased" # TEMPORARY OVERRIDE
+  branch = "master"
   name = "github.com/skeema/tengo"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,7 +34,7 @@
   name = "github.com/skeema/mybase"
 
 [[constraint]]
-  branch = "master"
+  branch = "routines-rebased" # TEMPORARY OVERRIDE
   name = "github.com/skeema/tengo"
 
 [[constraint]]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Additional [contributions](https://github.com/skeema/skeema/graphs/contributors)
 * [@efixler](https://github.com/efixler)
 * [@chrisjpalmer](https://github.com/chrisjpalmer)
 
+Support for stored procedures and functions generously sponsored by [Psyonix](https://psyonix.com).
+
 ## License
 
 **Copyright 2019 Skeema LLC**

--- a/applier/applier.go
+++ b/applier/applier.go
@@ -142,6 +142,7 @@ func StatementModifiersForDir(dir *fs.Dir) (mods tengo.StatementModifiers, err e
 	mods.NextAutoInc = tengo.NextAutoIncIfIncreased
 	forceAllowUnsafe := dir.Config.GetBool("brief") && dir.Config.GetBool("dry-run")
 	mods.AllowUnsafe = forceAllowUnsafe || dir.Config.GetBool("allow-unsafe")
+	mods.CompareMetadata = dir.Config.GetBool("compare-metadata")
 	if dir.Config.GetBool("exact-match") {
 		mods.StrictIndexOrder = true
 		mods.StrictForeignKeyNaming = true

--- a/applier/ddlstatement.go
+++ b/applier/ddlstatement.go
@@ -111,6 +111,13 @@ func NewDDLStatement(diff tengo.ObjectDiff, mods tengo.StatementModifiers, targe
 		ddl.connectParams = "foreign_key_checks=1"
 	}
 
+	// If creating a routine, use the server's global sql_mode instead of Skeema's
+	// normal built-in override
+	if wrapper == "" && (otype == tengo.ObjectTypeProc || otype == tengo.ObjectTypeFunc) &&
+		diff.DiffType() == tengo.DiffTypeCreate {
+		ddl.connectParams = "sql_mode=@@GLOBAL.sql_mode"
+	}
+
 	// Apply wrapper if relevant
 	if wrapper != "" {
 		var socket, port, connOpts string

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -31,6 +31,7 @@ top of the file. If no environment name is supplied, the default is
 	cmd.AddOption(mybase.BoolOption("first-only", '1', false, "For dirs mapping to multiple instances or schemas, just run against the first per dir"))
 	cmd.AddOption(mybase.BoolOption("exact-match", 0, false, "Follow *.sql table definitions exactly, even for differences with no functional impact"))
 	cmd.AddOption(mybase.BoolOption("foreign-key-checks", 0, false, "Force the server to check referential integrity of any new foreign key"))
+	cmd.AddOption(mybase.BoolOption("compare-metadata", 0, false, "For stored programs, detect changes to creation-time sql_mode or DB collation"))
 	cmd.AddOption(mybase.BoolOption("brief", 'q', false, "<overridden by diff command>").Hidden())
 	cmd.AddOption(mybase.StringOption("alter-wrapper", 'x', "", "External bin to shell out to for ALTER TABLE; see manual for template vars"))
 	cmd.AddOption(mybase.StringOption("alter-wrapper-min-size", 0, "0", "Ignore --alter-wrapper for tables smaller than this size in bytes"))

--- a/skeema.go
+++ b/skeema.go
@@ -16,7 +16,7 @@ schema to the filesystem, and apply online schema changes by modifying files.`
 
 // Globals overridden by GoReleaser's ldflags
 var (
-	version = "1.1.3-dev"
+	version = "1.2.0-dev"
 	commit  = "unknown"
 	date    = "unknown"
 )

--- a/skeema_cmd_test.go
+++ b/skeema_cmd_test.go
@@ -977,3 +977,128 @@ func (s SkeemaIntegrationSuite) TestShardedSchemas(t *testing.T) {
 	s.assertTableMissing(t, "product2", "foo2", "")
 	s.assertTableExists(t, "product3", "foo2", "")
 }
+
+func (s SkeemaIntegrationSuite) TestRoutines(t *testing.T) {
+	origCreate := `CREATE definer=root@localhost FUNCTION routine1(a int, b int)
+RETURNS int
+DETERMINISTIC
+BEGIN
+	return a * b;
+END`
+	create := origCreate
+	s.dbExec(t, "product", create)
+
+	// Confirm init works properly with one function present
+	s.reinitAndVerifyFiles(t, "", "../golden/routines")
+
+	// diff, pull, lint should all be no-ops at this point
+	s.handleCommand(t, CodeSuccess, ".", "skeema diff")
+	cfg := s.handleCommand(t, CodeSuccess, ".", "skeema pull")
+	s.verifyFiles(t, cfg, "../golden/routines")
+	cfg = s.handleCommand(t, CodeSuccess, ".", "skeema lint")
+	s.verifyFiles(t, cfg, "../golden/routines")
+
+	// Modify the db representation of the routine; diff/push should work, but only
+	// with --allow-unsafe (and not with --safe-below-size)
+	s.dbExec(t, "product", "DROP FUNCTION routine1")
+	create = strings.Replace(create, "a * b", "b * a", 1)
+	if create == origCreate {
+		t.Fatal("Test setup incorrect")
+	}
+	s.dbExec(t, "product", create)
+	s.handleCommand(t, CodeFatalError, ".", "skeema diff")
+	s.handleCommand(t, CodeDifferencesFound, ".", "skeema diff --allow-unsafe")
+	s.handleCommand(t, CodeFatalError, ".", "skeema push --safe-below-size=10000")
+	cfg = s.handleCommand(t, CodeSuccess, ".", "skeema push --allow-unsafe")
+	s.verifyFiles(t, cfg, "../golden/routines")
+	s.handleCommand(t, CodeSuccess, ".", "skeema diff")
+
+	// Delete that file and do a pull; file should be back, even with
+	// --skip-normalize
+	fs.RemoveTestFile(t, "mydb/product/routine1.sql")
+	cfg = s.handleCommand(t, CodeSuccess, ".", "skeema pull --skip-normalize")
+	s.verifyFiles(t, cfg, "../golden/routines")
+
+	// Confirm changing the db's collation counts as a diff for routines,
+	// even though the routine text is unaffected
+	s.dbExec(t, "", "ALTER DATABASE product DEFAULT COLLATE = latin1_general_ci")
+	s.handleCommand(t, CodeSuccess, ".", "skeema pull")
+	s.handleCommand(t, CodeDifferencesFound, ".", "skeema diff --allow-unsafe")
+	s.handleCommand(t, CodeSuccess, ".", "skeema push --allow-unsafe")
+	s.handleCommand(t, CodeSuccess, ".", "skeema diff")
+	s.d.CloseAll() // avoid mysql bug where ALTER DATABASE doesn't affect existing sessions
+
+	// Add a file creating another routine. Push it and confirm the routine is
+	// using the sql_mode of the server.
+	origContents := "CREATE FUNCTION routine2() returns varchar(30) DETERMINISTIC return 'abc''def';\n"
+	fs.WriteTestFile(t, "mydb/product/routine2.sql", origContents)
+	s.handleCommand(t, CodeSuccess, ".", "skeema push")
+	schema, err := s.d.Schema("product")
+	if err != nil || schema == nil {
+		t.Fatal("Unexpected error obtaining product schema")
+	}
+	funcs := schema.FunctionsByName()
+	if r2, ok := funcs["routine2"]; !ok {
+		t.Fatal("Unable to locate routine2")
+	} else {
+		var serverSQLMode string
+		db, _ := s.d.Connect("", "")
+		if err := db.QueryRow("SELECT @@global.sql_mode").Scan(&serverSQLMode); err != nil {
+			t.Fatalf("Unexpected error querying sql_mode: %s", err)
+		}
+		if r2.SQLMode != serverSQLMode {
+			t.Errorf("Expected routine2 to have sql_mode %s, instead found %s", serverSQLMode, r2.SQLMode)
+		}
+	}
+
+	// Lint that new file; confirm new formatting matches expectation.
+	s.handleCommand(t, CodeDifferencesFound, ".", "skeema lint")
+	normalizedContents := `CREATE DEFINER=~root~@~%~ FUNCTION ~routine2~() RETURNS varchar(30) CHARSET latin1 COLLATE latin1_general_ci
+    DETERMINISTIC
+return 'abc''def';
+`
+	normalizedContents = strings.Replace(normalizedContents, "~", "`", -1)
+	if contents := fs.ReadTestFile(t, "mydb/product/routine2.sql"); contents != normalizedContents {
+		t.Errorf("Unexpected contents after linting; found:\n%s", contents)
+	}
+
+	// Restore old formatting and test pull, with and without --normalize
+	fs.WriteTestFile(t, "mydb/product/routine2.sql", origContents)
+	s.handleCommand(t, CodeSuccess, ".", "skeema pull --skip-normalize")
+	if contents := fs.ReadTestFile(t, "mydb/product/routine2.sql"); contents != origContents {
+		t.Errorf("Expected contents unchanged from pull with --skip-normalize; instead found:\n%s", contents)
+	}
+	s.handleCommand(t, CodeSuccess, ".", "skeema pull")
+	if contents := fs.ReadTestFile(t, "mydb/product/routine2.sql"); contents != normalizedContents {
+		t.Errorf("Expected contents to be normalized from pull with --normalize; instead found:\n%s", contents)
+	}
+
+	// Add a *procedure* called routine2. pull should place this in same file as
+	// the function with same name.
+	r2dupe := `CREATE PROCEDURE routine2(a int, b int)
+BEGIN
+	SELECT a;
+	SELECT b;
+END`
+	s.dbExec(t, "product", r2dupe)
+	s.handleCommand(t, CodeSuccess, ".", "skeema pull")
+	normalizedContents += "DELIMITER //\nCREATE DEFINER=`root`@`%` PROCEDURE `routine2`(a int, b int)\nBEGIN\n\tSELECT a;\n\tSELECT b;\nEND//\nDELIMITER ;\n"
+	if contents := fs.ReadTestFile(t, "mydb/product/routine2.sql"); contents != normalizedContents {
+		t.Errorf("Unexpected contents after pull; expected:\n%s\nfound:\n%s", normalizedContents, contents)
+	}
+
+	// diff and lint should both be no-ops
+	s.handleCommand(t, CodeSuccess, ".", "skeema diff")
+	s.handleCommand(t, CodeSuccess, ".", "skeema lint")
+
+	// Drop the *function* routine2 and do a push. This should properly recreate
+	// the dropped func.
+	s.dbExec(t, "product", "DROP FUNCTION routine2")
+	s.handleCommand(t, CodeSuccess, ".", "skeema push")
+	for _, otype := range []tengo.ObjectType{tengo.ObjectTypeFunc, tengo.ObjectTypeProc} {
+		exists, phrase, err := s.objectExists("product", otype, "routine2", "")
+		if !exists || err != nil {
+			t.Errorf("Expected %s to exist, instead found %t, err=%v", phrase, exists, err)
+		}
+	}
+}

--- a/skeema_cmd_test.go
+++ b/skeema_cmd_test.go
@@ -1019,13 +1019,15 @@ END`
 	cfg = s.handleCommand(t, CodeSuccess, ".", "skeema pull --skip-normalize")
 	s.verifyFiles(t, cfg, "../golden/routines")
 
-	// Confirm changing the db's collation counts as a diff for routines,
-	// even though the routine text is unaffected
+	// Confirm changing the db's collation counts as a diff for routines if (and
+	// only if) --compare-metadata is used
 	s.dbExec(t, "", "ALTER DATABASE product DEFAULT COLLATE = latin1_general_ci")
 	s.handleCommand(t, CodeSuccess, ".", "skeema pull")
-	s.handleCommand(t, CodeDifferencesFound, ".", "skeema diff --allow-unsafe")
-	s.handleCommand(t, CodeSuccess, ".", "skeema push --allow-unsafe")
 	s.handleCommand(t, CodeSuccess, ".", "skeema diff")
+	s.handleCommand(t, CodeFatalError, ".", "skeema diff --compare-metadata")
+	s.handleCommand(t, CodeDifferencesFound, ".", "skeema diff --compare-metadata --allow-unsafe")
+	s.handleCommand(t, CodeSuccess, ".", "skeema push --compare-metadata --allow-unsafe")
+	s.handleCommand(t, CodeSuccess, ".", "skeema diff --compare-metadata")
 	s.d.CloseAll() // avoid mysql bug where ALTER DATABASE doesn't affect existing sessions
 
 	// Add a file creating another routine. Push it and confirm the routine is

--- a/testdata/golden-mariadb102/routines/mydb/.skeema
+++ b/testdata/golden-mariadb102/routines/mydb/.skeema
@@ -1,0 +1,4 @@
+[production]
+host=127.0.0.1
+port={DYNAMICALLY INSERTED BY TEST}
+flavor={DYNAMICALLY INSERTED BY TEST}

--- a/testdata/golden-mariadb102/routines/mydb/analytics/.skeema
+++ b/testdata/golden-mariadb102/routines/mydb/analytics/.skeema
@@ -1,0 +1,3 @@
+schema=analytics
+default-character-set=latin1
+default-collation=latin1_swedish_ci

--- a/testdata/golden-mariadb102/routines/mydb/analytics/activity.sql
+++ b/testdata/golden-mariadb102/routines/mydb/analytics/activity.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mariadb102/routines/mydb/analytics/pageviews.sql
+++ b/testdata/golden-mariadb102/routines/mydb/analytics/pageviews.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mariadb102/routines/mydb/analytics/rollups.sql
+++ b/testdata/golden-mariadb102/routines/mydb/analytics/rollups.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mariadb102/routines/mydb/product/.skeema
+++ b/testdata/golden-mariadb102/routines/mydb/product/.skeema
@@ -1,0 +1,3 @@
+schema=product
+default-character-set=latin1
+default-collation=latin1_swedish_ci

--- a/testdata/golden-mariadb102/routines/mydb/product/comments.sql
+++ b/testdata/golden-mariadb102/routines/mydb/product/comments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `comments` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `body` text DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mariadb102/routines/mydb/product/posts.sql
+++ b/testdata/golden-mariadb102/routines/mydb/product/posts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text DEFAULT NULL,
+  `created_at` datetime DEFAULT current_timestamp(),
+  `edited_at` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mariadb102/routines/mydb/product/routine1.sql
+++ b/testdata/golden-mariadb102/routines/mydb/product/routine1.sql
@@ -1,0 +1,7 @@
+DELIMITER //
+CREATE DEFINER=`root`@`localhost` FUNCTION `routine1`(a int, b int) RETURNS int(11)
+    DETERMINISTIC
+BEGIN
+	return a * b;
+END//
+DELIMITER ;

--- a/testdata/golden-mariadb102/routines/mydb/product/subscriptions.sql
+++ b/testdata/golden-mariadb102/routines/mydb/product/subscriptions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `subscriptions` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mariadb102/routines/mydb/product/users.sql
+++ b/testdata/golden-mariadb102/routines/mydb/product/users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT 10.00,
+  `last_modified` timestamp NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql55/routines/mydb/.skeema
+++ b/testdata/golden-mysql55/routines/mydb/.skeema
@@ -1,0 +1,4 @@
+[production]
+host=127.0.0.1
+port={DYNAMICALLY INSERTED BY TEST}
+flavor={DYNAMICALLY INSERTED BY TEST}

--- a/testdata/golden-mysql55/routines/mydb/analytics/.skeema
+++ b/testdata/golden-mysql55/routines/mydb/analytics/.skeema
@@ -1,0 +1,3 @@
+schema=analytics
+default-character-set=latin1
+default-collation=latin1_swedish_ci

--- a/testdata/golden-mysql55/routines/mydb/analytics/activity.sql
+++ b/testdata/golden-mysql55/routines/mydb/analytics/activity.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql55/routines/mydb/analytics/pageviews.sql
+++ b/testdata/golden-mysql55/routines/mydb/analytics/pageviews.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql55/routines/mydb/analytics/rollups.sql
+++ b/testdata/golden-mysql55/routines/mydb/analytics/rollups.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql55/routines/mydb/product/.skeema
+++ b/testdata/golden-mysql55/routines/mydb/product/.skeema
@@ -1,0 +1,3 @@
+schema=product
+default-character-set=latin1
+default-collation=latin1_swedish_ci

--- a/testdata/golden-mysql55/routines/mydb/product/comments.sql
+++ b/testdata/golden-mysql55/routines/mydb/product/comments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `comments` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `body` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql55/routines/mydb/product/posts.sql
+++ b/testdata/golden-mysql55/routines/mydb/product/posts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text,
+  `created_at` datetime DEFAULT NULL,
+  `edited_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql55/routines/mydb/product/routine1.sql
+++ b/testdata/golden-mysql55/routines/mydb/product/routine1.sql
@@ -1,0 +1,7 @@
+DELIMITER //
+CREATE DEFINER=`root`@`localhost` FUNCTION `routine1`(a int, b int) RETURNS int(11)
+    DETERMINISTIC
+BEGIN
+	return a * b;
+END//
+DELIMITER ;

--- a/testdata/golden-mysql55/routines/mydb/product/subscriptions.sql
+++ b/testdata/golden-mysql55/routines/mydb/product/subscriptions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `subscriptions` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql55/routines/mydb/product/users.sql
+++ b/testdata/golden-mysql55/routines/mydb/product/users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT '10.00',
+  `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql80/routines/mydb/.skeema
+++ b/testdata/golden-mysql80/routines/mydb/.skeema
@@ -1,0 +1,4 @@
+[production]
+host=127.0.0.1
+port={DYNAMICALLY INSERTED BY TEST}
+flavor={DYNAMICALLY INSERTED BY TEST}

--- a/testdata/golden-mysql80/routines/mydb/analytics/.skeema
+++ b/testdata/golden-mysql80/routines/mydb/analytics/.skeema
@@ -1,0 +1,3 @@
+schema=analytics
+default-character-set=utf8mb4
+default-collation=utf8mb4_0900_ai_ci

--- a/testdata/golden-mysql80/routines/mydb/analytics/activity.sql
+++ b/testdata/golden-mysql80/routines/mydb/analytics/activity.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql80/routines/mydb/analytics/pageviews.sql
+++ b/testdata/golden-mysql80/routines/mydb/analytics/pageviews.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql80/routines/mydb/analytics/rollups.sql
+++ b/testdata/golden-mysql80/routines/mydb/analytics/rollups.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql80/routines/mydb/product/.skeema
+++ b/testdata/golden-mysql80/routines/mydb/product/.skeema
@@ -1,0 +1,3 @@
+schema=product
+default-character-set=utf8mb4
+default-collation=utf8mb4_0900_ai_ci

--- a/testdata/golden-mysql80/routines/mydb/product/comments.sql
+++ b/testdata/golden-mysql80/routines/mydb/product/comments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `comments` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `body` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql80/routines/mydb/product/posts.sql
+++ b/testdata/golden-mysql80/routines/mydb/product/posts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `edited_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql80/routines/mydb/product/routine1.sql
+++ b/testdata/golden-mysql80/routines/mydb/product/routine1.sql
@@ -1,0 +1,7 @@
+DELIMITER //
+CREATE DEFINER=`root`@`localhost` FUNCTION `routine1`(a int, b int) RETURNS int(11)
+    DETERMINISTIC
+BEGIN
+	return a * b;
+END//
+DELIMITER ;

--- a/testdata/golden-mysql80/routines/mydb/product/subscriptions.sql
+++ b/testdata/golden-mysql80/routines/mydb/product/subscriptions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `subscriptions` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden-mysql80/routines/mydb/product/users.sql
+++ b/testdata/golden-mysql80/routines/mydb/product/users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT '10.00',
+  `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/routines/mydb/.skeema
+++ b/testdata/golden/routines/mydb/.skeema
@@ -1,0 +1,4 @@
+[production]
+host=127.0.0.1
+port={DYNAMICALLY INSERTED BY TEST}
+flavor={DYNAMICALLY INSERTED BY TEST}

--- a/testdata/golden/routines/mydb/analytics/.skeema
+++ b/testdata/golden/routines/mydb/analytics/.skeema
@@ -1,0 +1,3 @@
+schema=analytics
+default-character-set=latin1
+default-collation=latin1_swedish_ci

--- a/testdata/golden/routines/mydb/analytics/activity.sql
+++ b/testdata/golden/routines/mydb/analytics/activity.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `activity` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `action_id` int(10) unsigned NOT NULL,
+  `ts` int(10) unsigned NOT NULL,
+  `target_type` varchar(20) DEFAULT NULL,
+  `target_id` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`user_id`,`action_id`,`ts`),
+  KEY `by_target` (`target_id`,`target_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/routines/mydb/analytics/pageviews.sql
+++ b/testdata/golden/routines/mydb/analytics/pageviews.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pageviews` (
+  `url` varchar(200) NOT NULL,
+  `start_ts` int(10) unsigned NOT NULL,
+  `end_ts` int(10) unsigned NOT NULL,
+  `views` bigint(20) unsigned DEFAULT NULL,
+  `domain` varchar(40) NOT NULL,
+  PRIMARY KEY (`url`,`start_ts`,`end_ts`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/routines/mydb/analytics/rollups.sql
+++ b/testdata/golden/routines/mydb/analytics/rollups.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `rollups` (
+  `metric_id` int(10) unsigned NOT NULL,
+  `value` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`metric_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/routines/mydb/product/.skeema
+++ b/testdata/golden/routines/mydb/product/.skeema
@@ -1,0 +1,3 @@
+schema=product
+default-character-set=latin1
+default-collation=latin1_swedish_ci

--- a/testdata/golden/routines/mydb/product/comments.sql
+++ b/testdata/golden/routines/mydb/product/comments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `comments` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT NULL,
+  `body` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/routines/mydb/product/posts.sql
+++ b/testdata/golden/routines/mydb/product/posts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `posts` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` bigint(20) unsigned NOT NULL,
+  `body` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `edited_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `user_created` (`user_id`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/routines/mydb/product/routine1.sql
+++ b/testdata/golden/routines/mydb/product/routine1.sql
@@ -1,0 +1,7 @@
+DELIMITER //
+CREATE DEFINER=`root`@`localhost` FUNCTION `routine1`(a int, b int) RETURNS int(11)
+    DETERMINISTIC
+BEGIN
+	return a * b;
+END//
+DELIMITER ;

--- a/testdata/golden/routines/mydb/product/subscriptions.sql
+++ b/testdata/golden/routines/mydb/product/subscriptions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `subscriptions` (
+  `user_id` bigint(20) unsigned NOT NULL,
+  `post_id` bigint(20) unsigned NOT NULL,
+  `subscribed_at` int(10) unsigned DEFAULT NULL,
+  PRIMARY KEY (`post_id`,`user_id`),
+  KEY `user_post` (`user_id`,`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/golden/routines/mydb/product/users.sql
+++ b/testdata/golden/routines/mydb/product/users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  `credits` decimal(9,2) DEFAULT '10.00',
+  `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/testdata/nodelimiter1.sql
+++ b/testdata/nodelimiter1.sql
@@ -1,0 +1,15 @@
+# This should successfully parse, despite containing a multi-line proc
+# without using the DELIMITER command 
+CREATE PROCEDURE whatever(name varchar(10))
+BEGIN
+	DECLARE v1 INT;
+	SET v1=loops;
+	WHILE v1 > 0 DO
+		INSERT INTO users (name) values ('\xF0\x9D\x8C\x86');
+		SET v1 = v1 - (2 / 2); /* testing // testing */
+	END WHILE;
+END;
+
+
+-- another comment
+

--- a/testdata/nodelimiter2.sql
+++ b/testdata/nodelimiter2.sql
@@ -1,0 +1,12 @@
+# This should NOT parse "correctly" as a single proc without using the DELIMITER
+# command, due to the table after
+CREATE PROCEDURE whatever(name varchar(10))
+BEGIN
+DECLARE v1 INT;
+SET v1=loops;
+WHILE v1 > 0 DO
+INSERT INTO users (name) values ('\xF0\x9D\x8C\x86');
+SET v1 = v1 - (2 / 2);
+END WHILE;
+END;
+CREATE TABLE whatever(id int unsigned NOT NULL PRIMARY KEY);

--- a/testdata/statements.sql
+++ b/testdata/statements.sql
@@ -24,8 +24,25 @@ TABLE `users` (
 
 
 
+create function funcnodefiner() RETURNS varchar(30) RETURN "hello";
+CREATE DEFINER = CURRENT_USER() FUNCTION funccuruserparens() RETURNS int RETURN 42;
+CREATE DEFINER=CURRENT_USER PROCEDURE proccurusernoparens() # this is a comment!
+	SELECT 1;
+create definer=foo@'localhost' /*lol*/ FUNCTION analytics.funcdefquote2() RETURNS int RETURN 42;
+create DEFINER = 'foo'@localhost PROCEDURE `procdefquote1`() SELECT 42;
 	delimiter    "💩💩💩"
 CREATE TABLE uhoh (ummm varchar(20) default 'ok 💩💩💩 cool')💩💩💩
+DELIMITER //
+CREATE PROCEDURE whatever(name varchar(10))
+BEGIN
+	DECLARE v1 INT;
+	SET v1=loops;
+	WHILE v1 > 0 DO
+		INSERT INTO users (name) values ('\xF0\x9D\x8C\x86');
+		SET v1 = v1 - (2 / 2); /* testing // testing */
+	END WHILE;
+END
+//
 delimiter ;
 
 use /*wtf*/`analytics`;CREATE TABLE  if  NOT    eXiStS     `comments` (

--- a/vendor/github.com/skeema/tengo/README.md
+++ b/vendor/github.com/skeema/tengo/README.md
@@ -13,7 +13,7 @@ Most of Go La Tengo's current functionality is focused on MySQL schema introspec
 
 ### Schema introspection
 
-Go La Tengo examines several `information_schema` tables in order to build Go struct values representing schemas (databases), tables, columns, indexes, and foreign key constraints. These values can be diff'ed to generate corresponding DDL statements.
+Go La Tengo examines several `information_schema` tables in order to build Go struct values representing schemas (databases), tables, columns, indexes, foreign key constraints, stored procedures, and functions. These values can be diff'ed to generate corresponding DDL statements.
 
 ### Instance modeling
 
@@ -68,6 +68,8 @@ Additional [contributions](https://github.com/skeema/tengo/graphs/contributors) 
 * [@tomkrouper](https://github.com/tomkrouper)
 * [@efixler](https://github.com/efixler)
 * [@chrisjpalmer](https://github.com/chrisjpalmer)
+
+Support for stored procedures and functions generously sponsored by [Psyonix](https://psyonix.com).
 
 ## License
 

--- a/vendor/github.com/skeema/tengo/routine.go
+++ b/vendor/github.com/skeema/tengo/routine.go
@@ -1,0 +1,86 @@
+package tengo
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Routine represents a stored procedure or function.
+type Routine struct {
+	Name              string
+	Type              ObjectType // Will be ObjectTypeProcedure or ObjectTypeFunction
+	Body              string     // From information_schema; different char escaping vs CreateStatement
+	ParamString       string     // Formatted as per original CREATE
+	ReturnDataType    string     // Includes charset/collation when relevant
+	Definer           string
+	DatabaseCollation string // from creation time
+	Comment           string
+	Deterministic     bool
+	SQLDataAccess     string
+	SecurityType      string
+	SQLMode           string // sql_mode in effect at creation time
+	CreateStatement   string // complete SHOW CREATE obtained from an instance
+}
+
+// Definition generates and returns a canonical CREATE PROCEDURE or CREATE
+// FUNCTION statement based on the Routine's Go field values.
+func (r *Routine) Definition(flavor Flavor) string {
+	return fmt.Sprintf("%s%s", r.head(flavor), r.Body)
+}
+
+// head returns the portion of a CREATE statement prior to the body.
+func (r *Routine) head(_ Flavor) string {
+	var definer, returnClause, characteristics string
+
+	atPos := strings.LastIndex(r.Definer, "@")
+	if atPos >= 0 {
+		definer = fmt.Sprintf("%s@%s", EscapeIdentifier(r.Definer[0:atPos]), EscapeIdentifier(r.Definer[atPos+1:]))
+	}
+	if r.Type == ObjectTypeFunc {
+		returnClause = fmt.Sprintf(" RETURNS %s", r.ReturnDataType)
+	}
+
+	clauses := make([]string, 0)
+	if r.SQLDataAccess != "CONTAINS SQL" {
+		clauses = append(clauses, fmt.Sprintf("    %s\n", r.SQLDataAccess))
+	}
+	if r.Deterministic {
+		clauses = append(clauses, "    DETERMINISTIC\n")
+	}
+	if r.SecurityType != "DEFINER" {
+		clauses = append(clauses, fmt.Sprintf("    SQL SECURITY %s\n", r.SecurityType))
+	}
+	if r.Comment != "" {
+		clauses = append(clauses, fmt.Sprintf("    COMMENT '%s'\n", EscapeValueForCreateTable(r.Comment)))
+	}
+	characteristics = strings.Join(clauses, "")
+
+	return fmt.Sprintf("CREATE DEFINER=%s %s %s(%s)%s\n%s",
+		definer,
+		r.Type.Caps(),
+		EscapeIdentifier(r.Name),
+		r.ParamString,
+		returnClause,
+		characteristics)
+}
+
+// Equals returns true if two routines are identical, false otherwise.
+func (r *Routine) Equals(other *Routine) bool {
+	// shortcut if both nil pointers, or both pointing to same underlying struct
+	if r == other {
+		return true
+	}
+	// if one is nil, but the two pointers aren't equal, then one is non-nil
+	if r == nil || other == nil {
+		return false
+	}
+
+	// All fields are simple scalars, so we can just use equality check once we
+	// know neither is nil
+	return *r == *other
+}
+
+// DropStatement returns a SQL statement that, if run, would drop this routine.
+func (r *Routine) DropStatement() string {
+	return fmt.Sprintf("DROP %s %s", r.Type.Caps(), EscapeIdentifier(r.Name))
+}

--- a/vendor/github.com/skeema/tengo/tengo.go
+++ b/vendor/github.com/skeema/tengo/tengo.go
@@ -17,6 +17,8 @@ type ObjectType string
 const (
 	ObjectTypeDatabase ObjectType = "database"
 	ObjectTypeTable    ObjectType = "table"
+	ObjectTypeProc     ObjectType = "procedure"
+	ObjectTypeFunc     ObjectType = "function"
 )
 
 // Caps returns the object type as an uppercase string.


### PR DESCRIPTION
This PR adds support for stored procedures and functions:
* `skeema init` and `skeema pull` will write out procs/funcs to .sql files
* `skeema diff` and `skeema push` will compare procs/funcs in .sql files to those in the target db
* `skeema lint` will sanity-check procs/funcs in .sql files

A new diff/push option, --compare-metadata, has also been added. This controls whether or not Skeema considers creation-time db_collation and sql_mode when comparing procs/funcs.

This PR solves part of #41; the remaining parts will be split into new issues once this is merged.

I'm planning on merging this later today and then releasing as part of v1.2.0. However, Travis CI is currently having some sort of extended meltdown today, causing most CI builds to stall forever or fail randomly, so things may be slightly delayed.