### PR TITLE
Lint fixes

### DIFF
--- a/linter/linter.go
+++ b/linter/linter.go
@@ -28,9 +28,23 @@ func (a *Annotation) MessageWithLocation() string {
 		return fmt.Sprintf("%s [Full SQL: %s]", a.Message, a.Statement.Text)
 	}
 	if a.LineOffset == 0 && a.Statement.CharNo > 1 {
-		return fmt.Sprintf("%s:%d:%d: %s", a.Statement.File, a.Statement.LineNo, a.Statement.CharNo, a.Message)
+		return fmt.Sprintf("%s: %s", a.Location(), a.Message)
 	}
-	return fmt.Sprintf("%s:%d: %s", a.Statement.File, a.Statement.LineNo+a.LineOffset, a.Message)
+	return fmt.Sprintf("%s: %s", a.Location(), a.Message)
+}
+
+// Location returns the file, line number and character number where the
+// statement which is the cause of the Annotation was obtained from.
+func (a *Annotation) Location() string {
+	fileName := a.Statement.File
+	if fileName == "" {
+		fileName = "unknown"
+	}
+
+	if a.LineOffset == 0 && a.Statement.CharNo > 1 {
+		return fmt.Sprintf("%s:%d:%d", fileName, a.Statement.LineNo, a.Statement.CharNo)
+	}
+	return fmt.Sprintf("%s:%d", fileName, a.Statement.LineNo+a.LineOffset)
 }
 
 // Result is a combined set of linter annotations and/or Golang errors found
@@ -44,14 +58,28 @@ type Result struct {
 	Schemas       map[string]*tengo.Schema // Keyed by dir path and optionally schema name
 }
 
-// SortByFile implements the sort.Interface for []*Annotation based on
-// the Annotation.Statement.File field.
-type SortByFile []*Annotation
+// sortByFile implements the sort.Interface for []*Annotation to get a deterministic
+// sort order for Annotation lists.
+// sortByFile sorts the Annotation slice in lexicographical order
+// based on the file location (file name, line number and character number).
+// If two Annotations have the same line number the Problem name is used to
+// determine the order, it is assumed several locations can not be associatd
+// with the same problem type.
+type sortByFile []*Annotation
 
-func (a SortByFile) Len() int      { return len(a) }
-func (a SortByFile) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a SortByFile) Less(i, j int) bool {
-	return a[i].Statement.File < a[j].Statement.File
+func (a sortByFile) Len() int      { return len(a) }
+func (a sortByFile) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a sortByFile) Less(i, j int) bool {
+	loc0 := a[i].Location()
+	loc1 := a[j].Location()
+	switch {
+	case loc0 < loc1:
+		return true
+	case loc0 == loc1:
+		return a[i].Problem < a[j].Problem
+	default:
+		return false
+	}
 }
 
 // Merge combines other into r's value in-place.
@@ -79,9 +107,9 @@ func (r *Result) SortByFile() {
 		return
 	}
 
-	sort.Sort(SortByFile(r.Errors))
-	sort.Sort(SortByFile(r.Warnings))
-	sort.Sort(SortByFile(r.FormatNotices))
+	sort.Sort(sortByFile(r.Errors))
+	sort.Sort(sortByFile(r.Warnings))
+	sort.Sort(sortByFile(r.FormatNotices))
 }
 
 // BadConfigResult returns a *Result containing a single ConfigError in the

--- a/linter/problems.go
+++ b/linter/problems.go
@@ -71,7 +71,7 @@ func badCharsetDetector(schema *tengo.Schema, logicalSchema *fs.LogicalSchema, o
 					Statement:  logicalSchema.Creates[key],
 					LineOffset: findFirstLineOffset(re, stmt.Text),
 					Summary:    "Character set not permitted",
-					Message:    fmt.Sprintf("Column %s of table %s is using character set %s, which is not listed in option allow-charset", col.Name, table.Name, table.CharSet),
+					Message:    fmt.Sprintf("Column %s of table %s is using character set %s, which is not listed in option allow-charset", col.Name, table.Name, col.CharSet),
 				})
 				break // stop after the first disallowed charset col per table
 			}


### PR DESCRIPTION
This PR fixes a bug with the error message for bad charset on columns, the wrong charset was reported. It also makes sure the lint messages are sorted deterministically (by filename).