### PR TITLE
Add option to ignore .my.cnf file

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -596,6 +596,18 @@ Commands | pull
 
 If true, `skeema pull` will normalize the format of all *.sql files to match the canonical format shown in MySQL's `SHOW CREATE`, just like if `skeema lint` was called afterwards. If false, this step is skipped.
 
+### my-cnf
+
+Commands | *all*
+--- | :---
+**Default** | true
+**Type** | boolean
+**Restrictions** | none
+
+If false, skeema will skip reading of the `~/.my.cnf` for configuration information. If true, it will processed in order ([as specified by configuration priority](config.md#priority-of-options-set-in-multiple-places))
+
+Note that a file with higher priority can set this to option to false and disable the subsequent reading of the `~/.my.cnf` file. 
+
 ### password
 
 Commands | *all*

--- a/util/config.go
+++ b/util/config.go
@@ -39,7 +39,7 @@ func AddGlobalOptions(cmd *mybase.Command) {
 	cmd.AddOption(mybase.StringOption("docker-cleanup", 0, "NONE", `With --workspace=docker, specifies how to clean up containers (valid values: "NONE", "STOP", "DESTROY")`))
 	cmd.AddOption(mybase.BoolOption("reuse-temp-schema", 0, false, "Do not drop temp-schema when done"))
 	cmd.AddOption(mybase.BoolOption("debug", 0, false, "Enable debug logging"))
-	cmd.AddOption(mybase.BoolOption("ignore-my-cnf", 0, false, "Skips reading users's ~/.my.cnf file when determining configuration" ))
+	cmd.AddOption(mybase.BoolOption("my-cnf", 0, true, "If set to false, skips reading the ~/.my.cnf file for configuration"))
 }
 
 // AddGlobalConfigFiles takes the mybase.Config generated from the CLI and adds
@@ -51,20 +51,12 @@ func AddGlobalConfigFiles(cfg *mybase.Config) {
 	// running the test happens to have a ~/.my.cnf, ~/.skeema, /etc/skeema, it
 	// it would affect the test logic.
 	if cfg.IsTest {
-		if cfg.CLI.OptionValues["ignore-my-cnf"] == "1" {
-			globalFilePaths = append(globalFilePaths, path.Join("fake-etc/skeema"))
-		} else {
-			globalFilePaths = append(globalFilePaths, "fake-etc/skeema", "fake-home/.my.cnf")
-		}
+		globalFilePaths = append(globalFilePaths, "fake-etc/skeema", "fake-home/.my.cnf")
 	} else {
 		globalFilePaths = append(globalFilePaths, "/etc/skeema", "/usr/local/etc/skeema")
 		home := filepath.Clean(os.Getenv("HOME"))
 		if home != "" {
-			if cfg.CLI.OptionValues["ignore-my-cnf"] == "1" {
-				globalFilePaths = append(globalFilePaths, path.Join(home, ".skeema"))
-			} else {
-				globalFilePaths = append(globalFilePaths, path.Join(home, ".my.cnf"), path.Join(home, ".skeema"))
-			}
+			globalFilePaths = append(globalFilePaths, path.Join(home, ".my.cnf"), path.Join(home, ".skeema"))
 		}
 	}
 
@@ -80,6 +72,10 @@ func AddGlobalConfigFiles(cfg *mybase.Config) {
 		if strings.HasSuffix(path, ".my.cnf") {
 			f.IgnoreUnknownOptions = true
 			f.IgnoreOptions("host")
+
+			if !cfg.GetBool("my-cnf") {
+				continue
+			}
 		}
 		if err := f.Parse(cfg); err != nil {
 			log.Warnf("Ignoring global option file %s due to parse error: %s", f.Path(), err)

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -207,7 +207,7 @@ func TestConfigIgnoreOptions(t *testing.T) {
 	cmdSuite.AddSubCommand(cmd)
 
 	// Expectation: global config files not existing isn't fatal
-	cfg := mybase.ParseFakeCLI(t, cmdSuite, "skeema diff --ignore-my-cnf")
+	cfg := mybase.ParseFakeCLI(t, cmdSuite, "skeema diff --skip-my-cnf")
 	AddGlobalConfigFiles(cfg)
 	if actualPassword := cfg.Get("password"); actualPassword != "<no password>" {
 		t.Errorf("Expected password to be unchanged from default; instead found %s", actualPassword)
@@ -223,7 +223,7 @@ func TestConfigIgnoreOptions(t *testing.T) {
 	}()
 
 	// Expectation: both only the skeema file in etc gets used due to the override option
-	cfg = mybase.ParseFakeCLI(t, cmdSuite, "skeema diff --ignore-my-cnf")
+	cfg = mybase.ParseFakeCLI(t, cmdSuite, "skeema diff --skip-my-cnf")
 	AddGlobalConfigFiles(cfg)
 	if actualUser := cfg.Get("user"); actualUser != "one" {
 		t.Errorf("Expected user in fake-home/.my.cnf to be skipped; instead found %s", actualUser)


### PR DESCRIPTION
**Status**: open for discussion/review
**Related Issues**: #64 

## Changes
* Adds a `ignore-my-cnf` option to allow skipping the reading of the ~/.my.cnf file for config.
  * Note: This was originally requested as "skip-my-cnf", however skeema/mybase/option.go:183 strips out "skip", and "my-cnf" didn't seem like a very descriptive option name so I changed it to ignore. Let me know what you think!

Feature requested by #64