### PR TITLE
Foreign key lint detectors

### DIFF
--- a/linter/config.go
+++ b/linter/config.go
@@ -22,7 +22,7 @@ const (
 // AddCommandOptions adds linting-related mybase options to the supplied
 // mybase.Command.
 func AddCommandOptions(cmd *mybase.Command) {
-	cmd.AddOption(mybase.StringOption("warnings", 0, "bad-charset,bad-engine,no-pk", "Linter problems to display as warnings (non-fatal); see manual for usage"))
+	cmd.AddOption(mybase.StringOption("warnings", 0, "bad-charset,bad-engine,no-pk,non-unique-fk-ref,duplicate-fk,fk-missing-parent-table", "Linter problems to display as warnings (non-fatal); see manual for usage"))
 	cmd.AddOption(mybase.StringOption("errors", 0, "", "Linter problems to treat as fatal errors; see manual for usage"))
 	cmd.AddOption(mybase.StringOption("allow-charset", 0, "latin1,utf8mb4", "Whitelist of acceptable character sets"))
 	cmd.AddOption(mybase.StringOption("allow-engine", 0, "innodb", "Whitelist of acceptable storage engines"))

--- a/linter/config_test.go
+++ b/linter/config_test.go
@@ -50,8 +50,7 @@ func TestOptionsForDir(t *testing.T) {
 	}
 
 	// Confirm ConfigError implements Error interface and works as expected
-	var err error
-	err = ConfigError("testing ConfigError")
+	err := ConfigError("testing ConfigError")
 	if err.Error() != "testing ConfigError" {
 		t.Errorf("ConfigError not behaving as expected")
 	}

--- a/linter/foreignkey.go
+++ b/linter/foreignkey.go
@@ -1,0 +1,225 @@
+package linter
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/skeema/skeema/fs"
+	"github.com/skeema/tengo"
+)
+
+// Check that tables referenced from foreign key actually exist. If the parent and child tables of the FK are in
+// different schemas no check will be done.
+func parentTableMissingDetector(schema *tengo.Schema, logicalSchema *fs.LogicalSchema, _ Options) []*Annotation {
+	results := make([]*Annotation, 0)
+	for _, table := range schema.Tables {
+		for _, fk := range table.ForeignKeys {
+
+			// The referenced table is in another schema.
+			// The detectors only work on a per-schema basis, so we can't check the definition of the referenced columns.
+			// Do a silent skip for now.
+			// FIXME: Would be better to return an info annotation saying it can't be checked.
+			if fk.ReferencedSchemaName != "" {
+				continue
+			}
+
+			// Check if the referenced parent table exists, if not issue a warning.
+			referencedTable := schema.Table(fk.ReferencedTableName)
+			if referencedTable == nil {
+				key := tengo.ObjectKey{Type: tengo.ObjectTypeTable, Name: table.Name}
+				stmt := logicalSchema.Creates[key]
+				message := fmt.Sprintf("Foreign key `%s` references parent table `%s` which does not exist.", fk.Name, fk.ReferencedTableName)
+				re := regexp.MustCompile(fmt.Sprintf("(?i)(constraint)\\s*`(%s)`", fk.Name))
+				results = append(results, &Annotation{
+					Statement:  stmt,
+					Summary:    "Foreign key reference to unknown table",
+					Message:    message,
+					LineOffset: findFirstLineOffset(re, stmt.Text),
+				})
+			}
+
+		}
+	}
+
+	return results
+}
+
+// Checks if multiple foreign keys in the same table are equivalent.
+func duplicateForeignKeyDetector(schema *tengo.Schema, logicalSchema *fs.LogicalSchema, _ Options) []*Annotation {
+	results := make([]*Annotation, 0)
+	for _, table := range schema.Tables {
+		for i := 0; i < len(table.ForeignKeys); i++ {
+			for j := i + 1; j < len(table.ForeignKeys); j++ {
+				if table.ForeignKeys[i].Equivalent(table.ForeignKeys[j]) {
+					key := tengo.ObjectKey{Type: tengo.ObjectTypeTable, Name: table.Name}
+					stmt := logicalSchema.Creates[key]
+					message := fmt.Sprintf("Foreign key `%s` is a duplicate of `%s`", table.ForeignKeys[j].Name, table.ForeignKeys[i].Name)
+					re := regexp.MustCompile(fmt.Sprintf("(?i)(constraint)\\s*`(%s)`", table.ForeignKeys[j].Name))
+					results = append(results, &Annotation{
+						Statement:  stmt,
+						Summary:    "Duplicate foreign key",
+						Message:    message,
+						LineOffset: findFirstLineOffset(re, stmt.Text),
+					})
+				}
+			}
+		}
+	}
+	return results
+}
+
+// Check that the column(s) referenced in the parent table are declared as a primary or unique key.
+// If the parent and child tables of the FK are in different schemas no check will be done.
+func nonUniqueForeignKeyReferenceDetector(schema *tengo.Schema, logicalSchema *fs.LogicalSchema, _ Options) []*Annotation {
+	results := make([]*Annotation, 0)
+	for _, table := range schema.Tables {
+		for _, fk := range table.ForeignKeys {
+			// Check if referenced table is in the same schema as the child table.
+			if fk.ReferencedSchemaName != "" {
+				// The referenced table is in another schema, it has been handled by another detector.
+				// Just skip it.
+				continue
+			}
+
+			// Check if referenced table exists.
+			referencedTable := schema.Table(fk.ReferencedTableName)
+			if referencedTable == nil {
+				// Table doesn't exist, ignore it as it has been handled by another detector.
+				continue
+			}
+
+			// We only have the referenced columns as string names, wrap them in
+			// tengo.Column objects so we can work with them.
+			refCols := stringNamesToColumns(fk.ReferencedColumnNames)
+
+			// Find the index key that covers the columns
+			coveringKey := getCoveringKey(referencedTable, refCols)
+			if coveringKey == nil {
+				// With Innodb this is only possible when foreign key checks are disabled.
+				panic(errors.New("Invalid Foreign Key for Innodb, referenced columns are not indexed"))
+			}
+
+			if !coveringKey.Unique {
+				key := tengo.ObjectKey{Type: tengo.ObjectTypeTable, Name: table.Name}
+				stmt := logicalSchema.Creates[key]
+				message := fmt.Sprintf("Foreign key `%s` references a non-unique key", fk.Name)
+				re := regexp.MustCompile(fmt.Sprintf("(?i)(constraint)\\s*`(%s)`", fk.Name))
+				results = append(results, &Annotation{
+					Statement:  stmt,
+					Summary:    "Foreign key references non-unique key",
+					Message:    message,
+					LineOffset: findFirstLineOffset(re, stmt.Text),
+				})
+			}
+		}
+	}
+
+	return results
+}
+
+// Find a key in the given table that "covers" the given columns according to the Innodb engine.
+// A key covers the columns if the columns are equal to or left-prefix of the key.
+// For example:
+//  * The key (a) covers only the column (a)
+//  * The key (a,b) covers the columns (a) and (a,b)
+//  * The key (a,b,c,d) covers the columns (a), (a,b), (a,b,c) and (a,b,c,d)
+//
+// In addition InnoDB extends each secondary key by appending the primary key columns to it.
+// For example:
+//  * For a table with primary key (a) and a secondary key (b,c) the extended key becomes (b,c,a) and
+//    the any of {(b), (b,c), (b,c,a)} would be covered by the extended key.
+//  * For a table with primary key (a,b) and a secondary key (a,c), note that (a) occurs in both keys,
+//    the extended key would cover any of {(a), (a,c), (a,c,b)} but not (a,c,b,a,b) keys that already occured
+//    in the secondary key are filtered out from the PK when forming the extended key.
+//
+// This function returns the pointer to the index that covers the given columns.
+// If several keys cover the columns this function will return:
+//  1. If the table's PK covers the columns it is returned.
+//  2. If the PK does not cover the columns a random secondary key that covers the columns
+//     is returned.
+// Note that if a secondary key match dued to key extension the returned index will not include the
+// extension columns.
+//
+// FIXME: Use table.ClusteredIndexKey() instead of table.PrimaryKey?
+func getCoveringKey(table *tengo.Table, fkColumns []*tengo.Column) *tengo.Index {
+	fkColNames := make([]string, 0, len(fkColumns))
+	for _, c := range fkColumns {
+		fkColNames = append(fkColNames, c.Name)
+	}
+
+	if table.PrimaryKey != nil {
+		if keyIsCoveredBy(fkColNames, table.PrimaryKey.Columns) {
+			return table.PrimaryKey
+		}
+	}
+
+	for _, secondaryIndex := range table.SecondaryIndexes {
+		// Build the extended secondary key according to the InnoDB rules where the PK is appended
+		// to the secondary key columns.
+		if keyIsCoveredBy(fkColNames, extendKey(secondaryIndex.Columns, table.PrimaryKey.Columns)) {
+			return secondaryIndex
+		}
+	}
+
+	return nil
+}
+
+// Checks if the given column names are covered by the columns in the
+// given slice. It is covered if the column name slice is equal to
+// or forms a left-prefix of the columns in the column slice.
+func keyIsCoveredBy(colNames []string, cols []*tengo.Column) bool {
+	if len(colNames) > len(cols) {
+		return false
+	}
+
+	for i := 0; i < len(colNames); i++ {
+		if colNames[i] != cols[i].Name {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Build the InnoDB extended secondary key given a secondary and a primary key.
+// InnoDB extends each secondary key by appending the primary key columns to it.
+// For example:
+//  * For a table with primary key (a) and a secondary key (b,c) the extended key becomes (b,c,a) and
+//    the any of {(b), (b,c), (b,c,a)} would be covered by the extended key.
+//  * For a table with primary key (a,b) and a secondary key (a,c), note that (a) occurs in both keys,
+//    the extended key would cover any of {(a), (a,c), (a,c,b)} but not (a,c,b,a,b) keys that already occured
+//    in the secondary key are filtered out from the PK when forming the extended key.
+func extendKey(secondaryKey []*tengo.Column, primaryKey []*tengo.Column) []*tengo.Column {
+	if primaryKey == nil {
+		return secondaryKey
+	}
+
+	filteredPrimaryKey := make([]*tengo.Column, 0, len(primaryKey))
+pkLoop:
+	for i := 0; i < len(primaryKey); i++ {
+		for j := 0; j < len(secondaryKey); j++ {
+			// Don't append keys from primary key that already occur in the secondary key
+			if primaryKey[i].Name == secondaryKey[j].Name {
+				continue pkLoop
+			}
+		}
+		filteredPrimaryKey = append(filteredPrimaryKey, primaryKey[i])
+	}
+	extendedKey := make([]*tengo.Column, len(secondaryKey), len(filteredPrimaryKey)+len(secondaryKey))
+	copy(extendedKey, secondaryKey)
+	extendedKey = append(extendedKey, filteredPrimaryKey...)
+	return extendedKey
+}
+
+func stringNamesToColumns(names []string) []*tengo.Column {
+	refCols := make([]*tengo.Column, 0, len(names))
+	for _, n := range names {
+		c := tengo.Column{
+			Name: n,
+		}
+		refCols = append(refCols, &c)
+	}
+
+	return refCols
+}

--- a/linter/foreignkey_test.go
+++ b/linter/foreignkey_test.go
@@ -1,0 +1,178 @@
+package linter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/skeema/tengo"
+)
+
+func TestExtendedKey(t *testing.T) {
+	type testInput struct {
+		PrimaryKeyCols   []*tengo.Column
+		SecondaryKeyCols []*tengo.Column
+		ExpectedKeyCols  []*tengo.Column
+	}
+
+	extensionTests := []testInput{
+		testInput{
+			PrimaryKeyCols:   asColumns("c1"),
+			SecondaryKeyCols: asColumns("c2"),
+			ExpectedKeyCols:  asColumns("c2", "c1"),
+		},
+		testInput{
+			PrimaryKeyCols:   asColumns("c1"),
+			SecondaryKeyCols: asColumns("c2", "c3"),
+			ExpectedKeyCols:  asColumns("c2", "c3", "c1"),
+		},
+		testInput{
+			PrimaryKeyCols:   asColumns("c1"),
+			SecondaryKeyCols: asColumns("c2", "c1"),
+			ExpectedKeyCols:  asColumns("c2", "c1"),
+		},
+		testInput{
+			PrimaryKeyCols:   asColumns("c1", "c2", "c3", "c4"),
+			SecondaryKeyCols: asColumns("c3", "c2"),
+			ExpectedKeyCols:  asColumns("c3", "c2", "c1", "c4"),
+		},
+	}
+
+	for _, test := range extensionTests {
+		cols := extendKey(test.SecondaryKeyCols, test.PrimaryKeyCols)
+		if !reflect.DeepEqual(cols, test.ExpectedKeyCols) {
+			t.Errorf("Wrong extended key was returned. Secondary columns: %+v, PK columns: %+v, actual: %+v, expected: %+v",
+				asStringNames(test.SecondaryKeyCols),
+				asStringNames(test.PrimaryKeyCols),
+				asStringNames(cols),
+				asStringNames(test.ExpectedKeyCols))
+		}
+	}
+}
+
+func TestGetCoveringKey(t *testing.T) {
+	type testInput struct {
+		Table           *tengo.Table
+		TestCols        []*tengo.Column
+		ExpectedKeyCols []*tengo.Column
+	}
+
+	coveringTests := []testInput{
+		// Only Primary Key defined
+		testInput{
+			Table:           makeTable([]string{"c1"}, [][]string{}),
+			TestCols:        asColumns("c1"),
+			ExpectedKeyCols: asColumns("c1"),
+		},
+		testInput{
+			Table:           makeTable([]string{"c1"}, [][]string{}),
+			TestCols:        asColumns("c1", "c2"),
+			ExpectedKeyCols: nil,
+		},
+		testInput{
+			Table:           makeTable([]string{"c1"}, [][]string{}),
+			TestCols:        asColumns("c2"),
+			ExpectedKeyCols: nil,
+		},
+		testInput{
+			Table:           makeTable([]string{"c1", "c2"}, [][]string{}),
+			TestCols:        asColumns("c1"),
+			ExpectedKeyCols: asColumns("c1", "c2"),
+		},
+		testInput{
+			Table:           makeTable([]string{"c1", "c2"}, [][]string{}),
+			TestCols:        asColumns("c2"),
+			ExpectedKeyCols: nil,
+		},
+		testInput{
+			Table:           makeTable([]string{"c1", "c2", "c3", "c4"}, [][]string{}),
+			TestCols:        asColumns("c1", "c2", "c3"),
+			ExpectedKeyCols: asColumns("c1", "c2", "c3", "c4"),
+		},
+		// Only secondary keys defined
+		testInput{
+			Table:           makeTable([]string{}, [][]string{[]string{"c1"}}),
+			TestCols:        asColumns("c1"),
+			ExpectedKeyCols: asColumns("c1"),
+		},
+		testInput{
+			Table:           makeTable([]string{}, [][]string{[]string{"c1", "c2"}}),
+			TestCols:        asColumns("c1"),
+			ExpectedKeyCols: asColumns("c1", "c2"),
+		},
+		testInput{
+			Table:           makeTable([]string{}, [][]string{[]string{"c1", "c2"}, []string{"c2", "c3"}}),
+			TestCols:        asColumns("c1"),
+			ExpectedKeyCols: asColumns("c1", "c2"),
+		},
+		// PK and Secondary keys exists
+		testInput{ // Primary key chosen over secondary
+			Table:           makeTable([]string{"c1", "c2"}, [][]string{[]string{"c1", "c3"}}),
+			TestCols:        asColumns("c1"),
+			ExpectedKeyCols: asColumns("c1", "c2"),
+		},
+		testInput{ // Secondary matches
+			Table:           makeTable([]string{"c1", "c2"}, [][]string{[]string{"c1", "c3"}}),
+			TestCols:        asColumns("c1", "c3"),
+			ExpectedKeyCols: asColumns("c1", "c3"),
+		},
+		testInput{ // TestCols match the extended secondary key
+			Table:           makeTable([]string{"c1", "c2"}, [][]string{[]string{"c3", "c4"}}),
+			TestCols:        asColumns("c3", "c4", "c1"),
+			ExpectedKeyCols: asColumns("c3", "c4"),
+		},
+		testInput{ // c1 occurs multiple times in TestCols, no match
+			Table:           makeTable([]string{"c1", "c2"}, [][]string{[]string{"c1", "c3"}}),
+			TestCols:        asColumns("c1", "c3", "c1"),
+			ExpectedKeyCols: nil,
+		},
+	}
+
+	for _, test := range coveringTests {
+		key := getCoveringKey(test.Table, test.TestCols)
+		if key == nil && test.ExpectedKeyCols == nil {
+			// ok
+		} else if key == nil || !reflect.DeepEqual(key.Columns, test.ExpectedKeyCols) {
+			var keyCols []*tengo.Column
+			if key != nil {
+				keyCols = key.Columns
+			}
+			t.Errorf("Wrong covering key columns was returned. test columns: %+v, actual: %+v, expected: %+v",
+				asStringNames(test.TestCols),
+				asStringNames(keyCols),
+				asStringNames(test.ExpectedKeyCols))
+		}
+	}
+}
+
+// Helper to create a *tengo.Table with primary and secondary keys.
+func makeTable(pkKeys []string, secKeyCols [][]string) *tengo.Table {
+	secKeys := make([]*tengo.Index, 0, len(secKeyCols))
+	for _, names := range secKeyCols {
+		c := &tengo.Index{Columns: asColumns(names...), PrimaryKey: false}
+		secKeys = append(secKeys, c)
+	}
+	return &tengo.Table{
+		PrimaryKey:       &tengo.Index{Columns: asColumns(pkKeys...), PrimaryKey: true},
+		SecondaryIndexes: secKeys,
+	}
+}
+
+// Helper to create a slice of *tengo.Column from string names.
+func asColumns(names ...string) []*tengo.Column {
+	cols := make([]*tengo.Column, 0, len(names))
+	for _, n := range names {
+		c := tengo.Column{Name: n}
+		cols = append(cols, &c)
+	}
+
+	return cols
+}
+
+func asStringNames(cols []*tengo.Column) []string {
+	names := make([]string, 0, len(cols))
+	for _, c := range cols {
+		names = append(names, c.Name)
+	}
+
+	return names
+}

--- a/linter/problems.go
+++ b/linter/problems.go
@@ -23,9 +23,12 @@ func RegisterProblem(name string, fn Detector) {
 
 func init() {
 	problems = map[string]Detector{
-		"no-pk":       noPKDetector,
-		"bad-charset": badCharsetDetector,
-		"bad-engine":  badEngineDetector,
+		"no-pk":                   noPKDetector,
+		"bad-charset":             badCharsetDetector,
+		"bad-engine":              badEngineDetector,
+		"non-unique-fk-ref":       nonUniqueForeignKeyReferenceDetector,
+		"duplicate-fk":            duplicateForeignKeyDetector,
+		"fk-missing-parent-table": parentTableMissingDetector,
 	}
 }
 

--- a/linter/problems_test.go
+++ b/linter/problems_test.go
@@ -18,7 +18,7 @@ func TestProblemExists(t *testing.T) {
 }
 
 func TestAllProblemNames(t *testing.T) {
-	expected := []string{"bad-charset", "bad-engine", "no-pk"}
+	expected := []string{"bad-charset", "bad-engine", "duplicate-fk", "fk-missing-parent-table", "no-pk", "non-unique-fk-ref"}
 	actual := allProblemNames()
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("allProblemNames returned %+v, did not match expectation %+v", actual, expected)
@@ -30,7 +30,7 @@ func TestAllProblemNames(t *testing.T) {
 		// Clean up the global state
 		delete(problems, "new-prob")
 	}()
-	expected = []string{"bad-charset", "bad-engine", "new-prob", "no-pk"}
+	expected = []string{"bad-charset", "bad-engine", "duplicate-fk", "fk-missing-parent-table", "new-prob", "no-pk", "non-unique-fk-ref"}
 	actual = allProblemNames()
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("allProblemNames returned %+v, did not match expectation %+v", actual, expected)


### PR DESCRIPTION
This PR adds 3 foreign-key related lint detectors:
 1. `non-unique-fk-ref`
    InnoDB allows FK references to non-unique keys in the parent table but it is advised against in the mysql reference manual.
    Personally I came across this as I had issues with code generation tools (from schema to code) that didn't handle our FK references to non-unique keys.
    A lint warning should be useful.
 2. `fk-missing-parent-table`
    InnoDB lets you create a FK which references a non-existent table (with FOREIGN_KEY_CHECKS=0), added a detector for that.
    It doesn't seem to allow a reference to an existing table but non-existent column though, so not checking that.
 3. `duplicate-fk`
    Detects if there are several FK definitions that are identical (except for their names).

Some notes:
 * All the detectors assume that InnoDB is used but doesn't check the engine explicitly. AFAIK InnoDB is the only engine that checks the
   FKs, but it could still be interesting to check that they are valid in the linter? e.g. if FKs are used for documentation purposes.
 * The function `getCoveringKey(table *tengo.Table, fkColumns []*tengo.Column) *tengo.Index` is useful for other code as well and should    be moved to the `tengo` package as a method on `tengo.Table`.
 * I have only tested this with mysql 5.7.26.