### PR TITLE
Adding --ddl-wrapper-comment for diff output

### DIFF
--- a/applier/printer.go
+++ b/applier/printer.go
@@ -11,10 +11,10 @@ import (
 // being called from multiple pushworker goroutines.
 type Printer struct {
 	briefOutput        bool
-	wrapperComments    bool
 	lastStdoutInstance string
 	lastStdoutSchema   string
 	seenInstance       map[string]bool
+	wrapperComments    bool
 	*sync.Mutex
 }
 
@@ -25,8 +25,8 @@ type Printer struct {
 func NewPrinter(briefMode bool, wrapperComments bool) *Printer {
 	return &Printer{
 		briefOutput:     briefMode,
-		wrapperComments: wrapperComments,
 		seenInstance:    make(map[string]bool),
+		wrapperComments: wrapperComments,
 		Mutex:           new(sync.Mutex),
 	}
 }

--- a/applier/printer.go
+++ b/applier/printer.go
@@ -11,6 +11,7 @@ import (
 // being called from multiple pushworker goroutines.
 type Printer struct {
 	briefOutput        bool
+	wrapperComments    bool
 	lastStdoutInstance string
 	lastStdoutSchema   string
 	seenInstance       map[string]bool
@@ -21,11 +22,12 @@ type Printer struct {
 // printer is used to print instance names ("host:port\n") of instances that
 // have one or more differences found. If briefMode is false, this printer is
 // used to print any arbitrary output specific to an instance and schema.
-func NewPrinter(briefMode bool) *Printer {
+func NewPrinter(briefMode bool, wrapperComments bool) *Printer {
 	return &Printer{
-		briefOutput:  briefMode,
-		seenInstance: make(map[string]bool),
-		Mutex:        new(sync.Mutex),
+		briefOutput:     briefMode,
+		wrapperComments: wrapperComments,
+		seenInstance:    make(map[string]bool),
+		Mutex:           new(sync.Mutex),
 	}
 }
 
@@ -56,5 +58,11 @@ func (p *Printer) printDDL(ddl *DDLStatement) {
 		fmt.Printf("USE %s;\n", tengo.EscapeIdentifier(ddl.schemaName))
 		p.lastStdoutSchema = ddl.schemaName
 	}
+	if p.wrapperComments {
+		fmt.Print("-- skeema:ddl:begin\n")
+	}
 	fmt.Print(ddl.String())
+	if p.wrapperComments {
+		fmt.Print("-- skeema:ddl:end\n")
+	}
 }

--- a/cmd_diff.go
+++ b/cmd_diff.go
@@ -54,9 +54,10 @@ func clonePushOptionsToDiff() {
 		"safe-below-size": "Always permit generating destructive operations for tables below this size in bytes",
 	}
 	hiddenRewrites := map[string]bool{
-		"brief":              false,
-		"dry-run":            true,
-		"foreign-key-checks": true,
+		"brief":               false,
+		"ddl-wrapper-comment": false,
+		"dry-run":             true,
+		"foreign-key-checks":  true,
 	}
 
 	diffOptions := diff.Options()

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -34,6 +34,7 @@ top of the file. If no environment name is supplied, the default is
 	cmd.AddOption(mybase.BoolOption("foreign-key-checks", 0, false, "Force the server to check referential integrity of any new foreign key"))
 	cmd.AddOption(mybase.BoolOption("compare-metadata", 0, false, "For stored programs, detect changes to creation-time sql_mode or DB collation"))
 	cmd.AddOption(mybase.BoolOption("lint", 0, true, "Check modified objects for problems before proceeding"))
+	cmd.AddOption(mybase.BoolOption("ddl-wrapper-comment", 0, false, "Wrap DDL statements with marker comments"))
 	cmd.AddOption(mybase.BoolOption("brief", 'q', false, "<overridden by diff command>").Hidden())
 	cmd.AddOption(mybase.StringOption("alter-wrapper", 'x', "", "External bin to shell out to for ALTER TABLE; see manual for template vars"))
 	cmd.AddOption(mybase.StringOption("alter-wrapper-min-size", 0, "0", "Ignore --alter-wrapper for tables smaller than this size in bytes"))
@@ -56,7 +57,8 @@ func PushHandler(cfg *mybase.Config) error {
 	}
 
 	briefMode := dir.Config.GetBool("dry-run") && dir.Config.GetBool("brief")
-	printer := applier.NewPrinter(briefMode)
+	ddlWrapperComment := dir.Config.GetBool("ddl-wrapper-comment")
+	printer := applier.NewPrinter(briefMode, ddlWrapperComment)
 	g, ctx := errgroup.WithContext(context.Background())
 	tgchan, skipCount := applier.TargetGroupChanForDir(dir)
 	results := make(chan applier.Result)


### PR DESCRIPTION
A new flag is introduced, `--ddl-wrapper-comment` (bool, default `false` for backward compatibility), which controls output of `skeema diff` (or `skeema push --dry-run`) command.

When this flag is given, each DDL is wrapped by well formed comments, in the likeness of:
```
-- skeema:ddl:begin
CREATE TABLE `table_0` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `name` varchar(128) NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-- skeema:ddl:end
```

The purpose of this flag is to assist with parsing of `skeema diff` output. As a concrete example, we want to be able to run `skeema diff` and review the statements generated by the tool, on a per-statement basis. When `diff` contains multiple DDL statements (multiple `CREATE`, `ALTER`, `DROP`) it is a difficult task to parse it. Toekizing by semicolon (`;`) is unsafe, because a semicolon can appear as, say, a `VARCHAR`s default value, or in a column comment.

With the above wrapper comments the parsing operation is safe and simple. The wrapper comments text is extremely unlikely to appear as a valid text in a DDL.

---

I hope this PR finds you well. It confirms to existing coding standards. As I looked into a unit test, I found it difficult to follow the docker usage in generating & comparing diffs:

https://github.com/skeema/skeema/blob/94f380a5c46124ee743a221f9b2bb0b67b1c7859/skeema_cmd_test.go#L442-L453

I also noted the above uses `--brief` and so does not compare actual DDL statements; and so I'm unsure how to test wrapper statements. I'm happy to work on this with guidance, as needed.

cc @github/database-infrastructure