### PR TITLE
chore: add homebrew support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,14 @@ nfpms:
     formats:
     - deb
     - rpm
+brews:
+ -
+   name: skeema
+
+   tap:
+     owner: skeema
+     name: homebrew-tap
+
+   folder: Formula
+   homepage: https://www.skeema.io/
+   description: "Skeema is a tool for managing MySQL tables and schema changes in a declarative fashion using pure SQL."

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Skeema supports a pull-request-based workflow for schema change submission, revi
 
 Pre-built `skeema` binaries for Linux and macOS can be downloaded from the [releases](https://github.com/skeema/skeema/releases) page.
 
+### Homebrew on macOS
+
+If you are on macOS and using [Homebrew](https://brew.sh/) package manager, you can install skeema with Homebrew.
+
+```shell
+brew install skeema/tap/skeema
+```
+
 ## Compiling
 
 Compiling from scratch requires the [Go programming language toolchain](https://golang.org/dl/), version 1.13 or higher.
@@ -87,5 +95,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
-
-


### PR DESCRIPTION
GoReleaser will create/update a homebrew tap to allow MacOS users using Homebrew an easier installation and update procedure.

An empty repository `skeema/homebrew-tap` will need to be created which is used to write the "tap" file into (similar to https://github.com/goreleaser/homebrew-tap).

fixes #139