### PR TITLE
Add --json-output option for diff and push commands

### DIFF
--- a/applier/ddlstatement.go
+++ b/applier/ddlstatement.go
@@ -253,7 +253,9 @@ func (ddl *DDLStatement) String() string {
 	return fs.AddDelimiter(ddl.stmt)
 }
 
-func (ddl *DDLStatement) Json() (string, error) {
+// JSON returns the JSON represnetation of the ddl statement - specifically, its
+// variables field.
+func (ddl *DDLStatement) JSON() (string, error) {
 	b, err := json.Marshal(ddl.variables)
 	return string(b), err
 }

--- a/applier/ddlstatement_test.go
+++ b/applier/ddlstatement_test.go
@@ -50,18 +50,20 @@ func (s ApplierIntegrationSuite) TestNewDDLStatement(t *testing.T) {
 
 	// Hackily set up test args manually
 	configMap := map[string]string{
-		"user":                   "root",
-		"password":               s.d[0].Instance.Password,
-		"debug":                  "1",
-		"allow-unsafe":           "1",
-		"ddl-wrapper":            "/bin/echo ddl-wrapper {SCHEMA}.{NAME} {TYPE} {CLASS}",
-		"alter-wrapper":          "/bin/echo alter-wrapper {SCHEMA}.{TABLE} {TYPE} {CLAUSES}",
-		"alter-wrapper-min-size": "1",
-		"alter-algorithm":        "inplace",
-		"alter-lock":             "none",
-		"safe-below-size":        "0",
-		"connect-options":        "",
-		"environment":            "production",
+		"user":                         "root",
+		"password":                     s.d[0].Instance.Password,
+		"debug":                        "1",
+		"allow-unsafe":                 "1",
+		"ddl-wrapper":                  "/bin/echo ddl-wrapper {SCHEMA}.{NAME} {TYPE} {CLASS}",
+		"alter-wrapper":                "/bin/echo alter-wrapper {SCHEMA}.{TABLE} {TYPE} {CLAUSES}",
+		"alter-wrapper-min-size":       "1",
+		"alter-algorithm":              "inplace",
+		"alter-lock":                   "none",
+		"safe-below-size":              "0",
+		"connect-options":              "",
+		"environment":                  "production",
+		"json-output":                  "0",
+		"json-output-include-password": "0",
 	}
 	major, minor, _ := s.d[0].Version()
 	is55 := major == 5 && minor == 5

--- a/applier/printer.go
+++ b/applier/printer.go
@@ -51,7 +51,7 @@ func (p *Printer) printDDL(ddl *DDLStatement) {
 		return
 	}
 	if p.jsonOutput {
-		json, err := ddl.Json()
+		json, err := ddl.JSON()
 		if err != nil {
 			fmt.Printf("Error attempting to convert ddl variables to json: %s\n", err)
 		} else {

--- a/cmd_push.go
+++ b/cmd_push.go
@@ -29,6 +29,8 @@ top of the file. If no environment name is supplied, the default is
 	cmd.AddOption(mybase.BoolOption("verify", 0, true, "Test all generated ALTER statements on temp schema to verify correctness"))
 	cmd.AddOption(mybase.BoolOption("allow-unsafe", 0, false, "Permit running ALTER or DROP operations that are potentially destructive"))
 	cmd.AddOption(mybase.BoolOption("dry-run", 0, false, "Output DDL but don't run it; equivalent to `skeema diff`"))
+	cmd.AddOption(mybase.BoolOption("json-output", 0, false, "Output DDL statements as json instead of normal output."))
+	cmd.AddOption(mybase.BoolOption("json-output-include-password", 0, false, "Include password in the json output of ddl statements. Normal behaviour is to remove the password from the map before printing."))
 	cmd.AddOption(mybase.BoolOption("first-only", '1', false, "For dirs mapping to multiple instances or schemas, just run against the first per dir"))
 	cmd.AddOption(mybase.BoolOption("exact-match", 0, false, "Follow *.sql table definitions exactly, even for differences with no functional impact"))
 	cmd.AddOption(mybase.BoolOption("foreign-key-checks", 0, false, "Force the server to check referential integrity of any new foreign key"))
@@ -58,7 +60,8 @@ func PushHandler(cfg *mybase.Config) error {
 	}
 
 	briefMode := dir.Config.GetBool("dry-run") && dir.Config.GetBool("brief")
-	printer := applier.NewPrinter(briefMode)
+	jsonOutput := dir.Config.GetBool("json-output")
+	printer := applier.NewPrinter(briefMode, jsonOutput)
 	g, ctx := errgroup.WithContext(context.Background())
 	tgchan, skipCount := applier.TargetGroupChanForDir(dir)
 	results := make(chan applier.Result)

--- a/doc/options.md
+++ b/doc/options.md
@@ -37,6 +37,8 @@ This document is a reference, describing all options supported by Skeema. To lea
 * [ignore-schema](#ignore-schema)
 * [ignore-table](#ignore-table)
 * [include-auto-inc](#include-auto-inc)
+* [json-output](#json-output)
+* [json-output-include-password](#json-output-include-password)
 * [lint](#lint)
 * [lint-auto-inc](#lint-auto-inc)
 * [lint-charset](#lint-charset)
@@ -693,6 +695,26 @@ In `skeema init`, a false value omits AUTO_INCREMENT=X clauses in all table defi
 In `skeema pull`, a false value omits AUTO_INCREMENT=X clauses in any *newly-written* table files (tables were created outside of Skeema, which are now getting a \*.sql file written for the first time). Modified tables *that already had AUTO_INCREMENT=X clauses*, where X > 1, will have their AUTO_INCREMENT values updated; otherwise the clause will continue to be omitted in any file that previously omitted it. Meanwhile a true value causes all table files to now have AUTO_INCREMENT=X clauses.
 
 Only set this to true if you intentionally need to track auto_increment values in all tables. If only a few tables require nonstandard auto_increment, simply include the value manually in the CREATE TABLE statement in the *.sql file. Subsequent calls to `skeema pull` won't strip it, even if `include-auto-inc` is false.
+
+### json-output
+
+Commands | diff, push
+--- | :---
+**Default** | false
+**Type** | boolean
+**Restrictions** | Should only appear on command-line. Has no effect if [brief](#brief) is also set
+
+When enabled, replaces the standard SQL output with JSON output. The format consists of a JSON object stream, one object per DDL statement, with each object being a flat key-value map identical to what is available in [alter-wrapper](#alter-wrapper).
+
+### json-output-include-password
+
+Commands | diff, push
+--- | :---
+**Default** | false
+**Type** | boolean
+**Restrictions** | Has no effect unless [json-output](#json-output) also set
+
+By default, the JSON objects output by [json-output](#json-output) will _not_ include the MySQL password. This flag allows the password to also be returned in the JSON output.
 
 ### lint
 


### PR DESCRIPTION
The motivation for this flag is to leverage skeema as a component utility of a larger automated workflow, and utilize the information that skeema is able to determine (specifically, in my case, it's for Vitess). Trying to use the alter-wrapper and ddl-wrapper options in this case is fairly clumsy - I'd have to, what, make the ddl-wrapper an `echo` that spits out manually hand-cranked JSON, or something? 🤷

Example output:

```
skeema diff localhost --json-output
2020-10-15 14:36:58 [INFO]  Generating diff of 127.0.0.1:3306 test-schema vs /Users/santiclause/dev/schemas/test-schema/*.sql
{"CLASS":"DATABASE","CLAUSES":"","CONNOPTS":"innodb_strict_mode=0,sql_mode='ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'","DDL":"CREATE DATABASE `test-schema` CHARACTER SET latin1 COLLATE latin1_swedish_ci","DIRNAME":"test-schema","DIRPATH":"/Users/santiclause/dev/schemas/test-schema","ENVIRONMENT":"localhost","HOST":"127.0.0.1","NAME":"test-schema","PORT":"3306","SCHEMA":"","SIZE":"0","SOCKET":"","TABLE":"","TYPE":"CREATE","USER":"root"}
{"CLASS":"TABLE","CLAUSES":"(\n  `bar` varchar(50) NOT NULL,\n  PRIMARY KEY (`bar`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1","CONNOPTS":"innodb_strict_mode=0,sql_mode='ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'","DDL":"CREATE TABLE `foo` (\n  `bar` varchar(50) NOT NULL,\n  PRIMARY KEY (`bar`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1","DIRNAME":"test-schema","DIRPATH":"/Users/santiclause/dev/schemas/test-schema","ENVIRONMENT":"localhost","HOST":"127.0.0.1","NAME":"foo","PORT":"3306","SCHEMA":"test-schema","SIZE":"0","SOCKET":"","TABLE":"foo","TYPE":"CREATE","USER":"root"}
2020-10-15 14:36:58 [INFO]  127.0.0.1:3306 test-schema: diff complete
```