### PR TITLE
applier: abstract Printer with a DDLHandler

### DIFF
--- a/applier/applier.go
+++ b/applier/applier.go
@@ -44,10 +44,10 @@ func (r Result) Summary() string {
 // TargetGroups to read, it writes its aggregate Result to the output channel.
 // If a fatal error occurs, it will be returned immediately; Worker is meant to
 // be called via an errgroup (see golang.org/x/sync/errgroup).
-func Worker(ctx context.Context, targetGroups <-chan TargetGroup, results chan<- Result, printer *Printer) error {
+func Worker(ctx context.Context, targetGroups <-chan TargetGroup, results chan<- Result, handler DDLHandler) error {
 	for tg := range targetGroups {
 		for _, t := range tg {
-			result, err := applyTarget(t, printer)
+			result, err := applyTarget(t, handler)
 			if err != nil {
 				return err
 			}
@@ -64,7 +64,7 @@ func Worker(ctx context.Context, targetGroups <-chan TargetGroup, results chan<-
 	return nil
 }
 
-func applyTarget(t *Target, printer *Printer) (Result, error) {
+func applyTarget(t *Target, handler DDLHandler) (Result, error) {
 	var result Result
 
 	schemaFromInstance, err := t.SchemaFromInstance()
@@ -147,7 +147,7 @@ func applyTarget(t *Target, printer *Printer) (Result, error) {
 	}
 
 	// Print DDL; if not dry-run, execute it; final logging; return result
-	result.SkipCount += t.processDDL(ddls, printer)
+	result.SkipCount += t.processDDL(ddls, handler)
 	t.logApplyEnd(result)
 	return result, nil
 }

--- a/applier/ddlstatement.go
+++ b/applier/ddlstatement.go
@@ -257,3 +257,8 @@ func (ddl *DDLStatement) Execute() error {
 	_, err = db.Exec(ddl.stmt)
 	return err
 }
+
+// Instance returns the tengo.Instance where this statement is supposed to run
+func (ddl *DDLStatement) Instance() *tengo.Instance {
+	return ddl.instance
+}

--- a/applier/handler.go
+++ b/applier/handler.go
@@ -7,7 +7,12 @@ import (
 	"github.com/skeema/tengo"
 )
 
-// Printer is capable of sending output to STDOUT in a readable manner despite
+// DDLHandler handles each of the DDL statements in a push/diff operation.
+type DDLHandler interface {
+	HandleDDL(ddl *DDLStatement)
+}
+
+// Printer implements DDLHandler and is capable of sending output to STDOUT in a readable manner despite
 // being called from multiple pushworker goroutines.
 type Printer struct {
 	briefOutput        bool
@@ -29,10 +34,10 @@ func NewPrinter(briefMode bool) *Printer {
 	}
 }
 
-// printDDL outputs DDLStatement values to STDOUT in a way that prevents
+// HandleDDL outputs DDLStatement values to STDOUT in a way that prevents
 // interleaving of output from multiple workers.
 // TODO: buffer output from external commands and also prevent interleaving there
-func (p *Printer) printDDL(ddl *DDLStatement) {
+func (p *Printer) HandleDDL(ddl *DDLStatement) {
 	p.Lock()
 	defer p.Unlock()
 	instString := ddl.instance.String()

--- a/applier/target.go
+++ b/applier/target.go
@@ -73,9 +73,9 @@ func (t *Target) logApplyEnd(result Result) {
 	}
 }
 
-func (t *Target) processDDL(ddls []*DDLStatement, printer *Printer) (skipCount int) {
+func (t *Target) processDDL(ddls []*DDLStatement, handler DDLHandler) (skipCount int) {
 	for i, ddl := range ddls {
-		printer.printDDL(ddl)
+		handler.HandleDDL(ddl)
 		if !t.dryRun() {
 			if err := ddl.Execute(); err != nil {
 				log.Errorf("Error running DDL on %s %s: %s", t.Instance, t.SchemaName, err)


### PR DESCRIPTION
Hii @evanelias!

We're trying to integrate a bit closer with Skeema as a library, rather than shelling out to it as a commandline tool. To accomplish this, we'd need a few abstractions that don't assume we're performing operations directly on the CLI.

I hope these small refactoring seem sensible to you; I've made sure that the behaviour for Skeema when run as a CLI tool is 100% identical to what it was before.

Thanks!

cc @shlomi-noach @piki