### PR TITLE
lint-has-time: improve annotation text

### DIFF
--- a/internal/linter/check_has_time.go
+++ b/internal/linter/check_has_time.go
@@ -16,20 +16,45 @@ func init() {
 	})
 }
 
-func hasTimeChecker(table *tengo.Table, createStatement string, _ *tengo.Schema, _ Options) []Note {
+func hasTimeChecker(table *tengo.Table, createStatement string, _ *tengo.Schema, opts Options) []Note {
 	results := make([]Note, 0)
+	onlyWarning := (opts.RuleSeverity["has-time"] == SeverityWarning)
+	oldTimestampDefaults := !opts.Flavor.Min(tengo.FlavorMySQL80) && !opts.Flavor.Min(tengo.FlavorMariaDB1010)
+	var alreadySeenTimestamp bool
 	for _, col := range table.Columns {
-		if strings.Contains(col.TypeInDB, "time") {
-			message := fmt.Sprintf(
-				"Column %s of table %s is using type %s. Temporal data types can be problematic when dealing with timezone conversions, daylight savings time transitions, and leap seconds. Some companies prefer to store time-related values using unsigned ints or unsigned bigints for this reason.",
+		var message string
+		if strings.HasPrefix(col.TypeInDB, "timestamp") {
+			message = fmt.Sprintf(
+				"Column %s of table %s is using type timestamp. This column type cannot store values beyond January 2038, which is problematic for software with long-term support requirements. It should not be used for storing arbitrary future dates, especially from user input.\nAlso note that timestamps have automatic timezone conversion behavior, between the time_zone session variable and UTC.",
+				col.Name, table.Name,
+			)
+			if oldTimestampDefaults && !alreadySeenTimestamp && !col.Nullable {
+				when := "MySQL 8"
+				if opts.Flavor.IsMariaDB() {
+					when = "MariaDB 10.10+"
+				}
+				message += "\nFinally, the automatic DEFAULT / ON UPDATE timestamp behavior depends on the explicit_defaults_for_timestamp system variable, which will flip from default OFF to default ON if you upgrade to " + when + "."
+			}
+			alreadySeenTimestamp = true
+		} else if strings.Contains(col.TypeInDB, "time") {
+			message = fmt.Sprintf(
+				"Column %s of table %s is using type %s. Please note this data type does not include timezone information, and does not perform automatic timezone conversions on storage or retrieval.",
 				col.Name, table.Name, col.TypeInDB,
 			)
-			results = append(results, Note{
-				LineOffset: FindColumnLineOffset(col, createStatement),
-				Summary:    "Column using temporal type",
-				Message:    message,
-			})
+			if onlyWarning {
+				message += " Consider strictly using UTC in all contexts to prevent issues with timezone conversions and daylight savings time transitions."
+			}
+		} else {
+			continue
 		}
+		if !onlyWarning {
+			message += "\nTo avoid these issues, consider storing temporal data using unsigned ints or unsigned bigints."
+		}
+		results = append(results, Note{
+			LineOffset: FindColumnLineOffset(col, createStatement),
+			Summary:    "Column using temporal type",
+			Message:    message,
+		})
 	}
 	return results
 }


### PR DESCRIPTION
This commit improves lint-has-time's annotation message as follows:

* For TIMESTAMP columns, mention the Y2K38 problem of this data type. Resolves #209.

* If the DB is running MySQL 5.7 (or older) or MariaDB 10.9 (or older), mention the upgrade complications involving explicit_defaults_for_timestamp for the first TIMESTAMP column in a table.

* Explain that TIMESTAMP columns perform automatic UTC conversion for storage and retrieval, while DATETIME and TIME do not.

* If lint-has-time=warning, omit the text about preferring ints instead of temporal types. This messaging only makes sense for companies who are strictly banning temporal types (lint-has-time=error), typically due to being stuck on a non-UTC time_zone setting which cannot be adjusted without skewing DATETIME values relative to TIMESTAMP values.

Web documentation for lint-has-time will also be expanded to cover these situations in more detail.
