### PR TITLE
lint,diff,push: strip linter annotation newlines if non-TTY STDERR

### DIFF
--- a/cmd_lint.go
+++ b/cmd_lint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/skeema/skeema/internal/fs"
 	"github.com/skeema/skeema/internal/linter"
 	"github.com/skeema/skeema/internal/tengo"
+	"github.com/skeema/skeema/internal/util"
 	"github.com/skeema/skeema/internal/workspace"
 )
 
@@ -121,6 +122,7 @@ func lintWalker(dir *fs.Dir, maxDepth int) *linter.Result {
 // returned. This function does not recurse into subdirs.
 func lintDir(dir *fs.Dir) *linter.Result {
 	opts, err := linter.OptionsForDir(dir)
+	opts.StripAnnotationNewlines = !util.StderrIsTerminal()
 	if err != nil && len(dir.LogicalSchemas) > 0 {
 		return linter.BadConfigResult(dir, err)
 	}

--- a/internal/applier/applier.go
+++ b/internal/applier/applier.go
@@ -9,6 +9,7 @@ import (
 	"github.com/skeema/skeema/internal/fs"
 	"github.com/skeema/skeema/internal/linter"
 	"github.com/skeema/skeema/internal/tengo"
+	"github.com/skeema/skeema/internal/util"
 )
 
 // ClientState provides information on where and how a SQL statement would be
@@ -137,6 +138,7 @@ func ApplyTarget(t *Target, printer Printer) (Result, error) {
 			return result, ConfigError(err.Error())
 		}
 		lintOpts.OnlyKeys(keys)
+		lintOpts.StripAnnotationNewlines = !util.StderrIsTerminal()
 		lintResult := linter.CheckSchema(t.DesiredSchema, lintOpts)
 		lintResult.SortByFile()
 		for _, annotation := range lintResult.Annotations {

--- a/internal/linter/config.go
+++ b/internal/linter/config.go
@@ -39,10 +39,11 @@ func AddCommandOptions(cmd *mybase.Command) {
 
 // Options contains parsed settings controlling linter behavior.
 type Options struct {
-	RuleSeverity map[string]Severity
-	RuleConfig   map[string]interface{}
-	Flavor       tengo.Flavor
-	onlyKeys     map[tengo.ObjectKey]bool // if map is non-nil, only format objects with true values
+	RuleSeverity            map[string]Severity
+	RuleConfig              map[string]interface{}
+	Flavor                  tengo.Flavor
+	StripAnnotationNewlines bool                     // if true, remove newlines inside annotation messages
+	onlyKeys                map[tengo.ObjectKey]bool // if map is non-nil, only format objects with true values
 }
 
 // AllowList returns a slice of configured allowed values for the given rule.

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -3,6 +3,7 @@ package linter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/skeema/mybase"
 	"github.com/skeema/skeema/internal/tengo"
@@ -31,6 +32,9 @@ func CheckSchema(wsSchema *workspace.Schema, opts Options) *Result {
 			r := rulesByName[ruleName]
 			output := r.CheckerFunc.CheckObject(object, stmt.Text, wsSchema.Schema, opts)
 			for _, lo := range output {
+				if opts.StripAnnotationNewlines {
+					lo.Message = strings.ReplaceAll(lo.Message, "\n", " ")
+				}
 				result.Annotate(stmt, severity, ruleName, lo)
 			}
 		}

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -173,7 +173,7 @@ var PasswordPromptInput PasswordInputSource
 func init() {
 	// Don't attempt interactive password prompt if STDIN isn't a TTY, or if
 	// running a test suite
-	if !terminal.IsTerminal(int(os.Stdin.Fd())) || strings.HasSuffix(os.Args[0], ".test") || strings.HasSuffix(os.Args[0], ".test.exe") {
+	if !StdinIsTerminal() || strings.HasSuffix(os.Args[0], ".test") || strings.HasSuffix(os.Args[0], ".test.exe") {
 		PasswordPromptInput = PasswordInputSource(NoInteractiveInput)
 	} else {
 		PasswordPromptInput = PasswordInputSource(InteractivePasswordInput)
@@ -192,7 +192,7 @@ func PromptPassword(promptArgs ...interface{}) (string, error) {
 	}
 
 	w := os.Stderr
-	if !terminal.IsTerminal(int(w.Fd())) && terminal.IsTerminal(int(os.Stdout.Fd())) {
+	if !StderrIsTerminal() && StdoutIsTerminal() {
 		w = os.Stdout
 	}
 	fmt.Fprintf(w, promptArgs[0].(string), promptArgs[1:]...)


### PR DESCRIPTION
Linter annotation messages sometimes contain embedded newlines, which can make automated parsing of these messages difficult. This PR adjusts linter output to strip embedded newlines whenever STDERR isn't a terminal. In this situation, spaces are now used in place of newlines, so each linter annotation is guaranteed to be a single log line.

Note that non-linter-related log messages may still contain embedded newlines. In that situation, if STDERR isn't a terminal, each log line repeats the log message header with timestamp and severity.

The logic in this PR only pays attention to STDERR (and not STDOUT) since Skeema log messages always go to STDERR. In `skeema diff` and `skeema push`, STDOUT is used for emitting SQL. In `skeema lint`, STDOUT is currently unused.

This PR also adds some utility functions for making it easier to check whether a file descriptor is a terminal.