### PR TITLE
Ignore column order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+### ⚠️ This is a fork of Skeema that's configured to ignore column order ⚠️ 
+This is a feature that's [been requested](https://github.com/skeema/skeema/issues/178) but has had no movement. 
+
 [![Skeema](https://www.skeema.io/img/logo.png)](https://www.skeema.io)
 
 [![build status](https://img.shields.io/github/actions/workflow/status/skeema/skeema/tests.yml?branch=main)](https://github.com/skeema/skeema/actions)

--- a/internal/tengo/alterclause.go
+++ b/internal/tengo/alterclause.go
@@ -282,26 +282,15 @@ var reDisplayWidth = regexp.MustCompile(`(tinyint|smallint|mediumint|int|bigint)
 
 // Clause returns a MODIFY COLUMN clause of an ALTER TABLE statement.
 func (mc ModifyColumn) Clause(mods StatementModifiers) string {
-	var positionClause string
-	if mc.PositionFirst {
-		// Positioning variables are mutually exclusive
-		if mc.PositionAfter != nil {
-			panic(fmt.Errorf("Modified column %s cannot be both first and after another column", mc.NewColumn.Name))
-		}
-		positionClause = " FIRST"
-	} else if mc.PositionAfter != nil {
-		positionClause = fmt.Sprintf(" AFTER %s", EscapeIdentifier(mc.PositionAfter.Name))
-	}
-
 	// Emit a no-op if we're not re-ordering the column and it only has cosmetic
 	// differences, such as presence/lack of int display width, or presence/lack
 	// of charset/collation clauses that are equal to the table's defaults anyway.
 	// (These situations only come up in MySQL 8, under various edge cases.)
-	if !mods.StrictColumnDefinition && positionClause == "" && mc.OldColumn.Equivalent(mc.NewColumn) {
+	if !mods.StrictColumnDefinition && mc.OldColumn.Equivalent(mc.NewColumn) {
 		return ""
 	}
 
-	return fmt.Sprintf("MODIFY COLUMN %s%s", mc.NewColumn.Definition(mods.Flavor, mc.Table), positionClause)
+	return fmt.Sprintf("MODIFY COLUMN %s", mc.NewColumn.Definition(mods.Flavor, mc.Table))
 }
 
 // Unsafe returns true if this clause is potentially destructive of data.


### PR DESCRIPTION
We've been using Alembic in our projects which doesn't care about column order, so when using Skeema for the first time it generates huge diffs. This change ignores column order so Skeema only produces functional changes.