### PR TITLE
skeema init: Remove extra newlines in logging

### DIFF
--- a/cmd_init.go
+++ b/cmd_init.go
@@ -185,7 +185,7 @@ func createHostOptionFile(cfg *mybase.Config, hostDir *fs.Dir, inst *tengo.Insta
 	if cfg.Changed("schema") {
 		suffix = "; skipping schema-level subdirs"
 	}
-	log.Infof("Using host dir %s for %s%s\n", hostDir.Path, inst, suffix)
+	log.Infof("Using host dir %s for %s%s", hostDir.Path, inst, suffix)
 	return nil
 }
 
@@ -246,6 +246,5 @@ func PopulateSchemaDir(s *tengo.Schema, parentDir *fs.Dir, makeSubdir bool) erro
 	if _, err = dumper.DumpSchema(s, dir, dumpOpts); err != nil {
 		return NewExitValue(CodeCantCreate, "Unable to write in %s: %s", dir, err)
 	}
-	os.Stderr.WriteString("\n")
 	return nil
 }


### PR DESCRIPTION
Before:
```
$ skeema init --host 127.0.0.1 -P 4000
2023-08-21 11:01:37 [INFO]  Using host dir /tmp/s/127.0.0.1:4000 for 127.0.0.1:4000
                            
2023-08-21 11:01:37 [INFO]  Populating /tmp/s/127.0.0.1:4000/blog
2023-08-21 11:01:37 [INFO]  Created /tmp/s/127.0.0.1:4000/blog/authors.sql (251 bytes)
2023-08-21 11:01:37 [INFO]  Created /tmp/s/127.0.0.1:4000/blog/comments.sql (516 bytes)
2023-08-21 11:01:37 [INFO]  Created /tmp/s/127.0.0.1:4000/blog/posts.sql (632 bytes)

2023-08-21 11:01:37 [INFO]  Populating /tmp/s/127.0.0.1:4000/INFORMATION_SCHEMA

2023-08-21 11:01:37 [INFO]  Populating /tmp/s/127.0.0.1:4000/METRICS_SCHEMA

2023-08-21 11:01:37 [INFO]  Populating /tmp/s/127.0.0.1:4000/PERFORMANCE_SCHEMA

```

With this PR:
```
[dvaneeden@dve-carbon s]$ skeema init --host 127.0.0.1 -P 4000
2023-08-21 11:08:20 [INFO]  Using host dir /tmp/s/127.0.0.1:4000 for 127.0.0.1:4000
2023-08-21 11:08:20 [INFO]  Populating /tmp/s/127.0.0.1:4000/blog
2023-08-21 11:08:20 [INFO]  Created /tmp/s/127.0.0.1:4000/blog/posts.sql (632 bytes)
2023-08-21 11:08:20 [INFO]  Created /tmp/s/127.0.0.1:4000/blog/authors.sql (251 bytes)
2023-08-21 11:08:20 [INFO]  Created /tmp/s/127.0.0.1:4000/blog/comments.sql (516 bytes)
2023-08-21 11:08:20 [INFO]  Populating /tmp/s/127.0.0.1:4000/INFORMATION_SCHEMA
2023-08-21 11:08:20 [INFO]  Populating /tmp/s/127.0.0.1:4000/METRICS_SCHEMA
2023-08-21 11:08:20 [INFO]  Populating /tmp/s/127.0.0.1:4000/PERFORMANCE_SCHEMA
```