### PR TITLE
Initial TiDB support

### DIFF
--- a/cmd_init.go
+++ b/cmd_init.go
@@ -98,6 +98,9 @@ func InitHandler(cfg *mybase.Config) error {
 
 	// Iterate over the schemas. For each one, create a dir with .skeema and *.sql files
 	for _, s := range schemas {
+		if inst.IsSystemSchema(s.Name) { // skip over system schemas
+			continue
+		}
 		s.StripMatches(hostDir.IgnorePatterns)
 		if err := PopulateSchemaDir(s, hostDir, separateSchemaSubdir); err != nil {
 			return err

--- a/internal/tengo/flavor.go
+++ b/internal/tengo/flavor.go
@@ -114,6 +114,7 @@ type Variant uint32
 const (
 	VariantPercona Variant = 1 << iota
 	VariantAurora
+	VariantTiDB
 )
 
 // Variant zero value constants can either express no variant or unknown variants.
@@ -130,6 +131,9 @@ func (variant Variant) String() string {
 	}
 	if variant&VariantAurora != 0 {
 		ss = append(ss, "aurora")
+	}
+	if variant&VariantTiDB != 0 {
+		ss = append(ss, "tidb")
 	}
 	return strings.Join(ss, "-")
 }
@@ -186,6 +190,8 @@ var (
 	FlavorPercona57   = Flavor{Vendor: VendorMySQL, Version: Version{5, 7, 0}, Variants: VariantPercona}
 	FlavorPercona80   = Flavor{Vendor: VendorMySQL, Version: Version{8, 0, 0}, Variants: VariantPercona}
 	FlavorPercona81   = Flavor{Vendor: VendorMySQL, Version: Version{8, 1, 0}, Variants: VariantPercona}
+	FlavorTiDB57      = Flavor{Vendor: VendorMySQL, Version: Version{5, 7, 0}, Variants: VariantTiDB}
+	FlavorTiDB80      = Flavor{Vendor: VendorMySQL, Version: Version{8, 0, 0}, Variants: VariantTiDB}
 	FlavorMariaDB101  = Flavor{Vendor: VendorMariaDB, Version: Version{10, 1, 0}}
 	FlavorMariaDB102  = Flavor{Vendor: VendorMariaDB, Version: Version{10, 2, 0}}
 	FlavorMariaDB103  = Flavor{Vendor: VendorMariaDB, Version: Version{10, 3, 0}}
@@ -228,6 +234,9 @@ func IdentifyFlavor(versionString, versionComment string) (flavor Flavor) {
 	if strings.Contains(versionComment, "percona") || strings.Contains(versionString, "percona") {
 		flavor.Vendor = VendorMySQL
 		flavor.Variants = VariantPercona
+	} else if strings.Contains(versionComment, "tidb") || strings.Contains(versionString, "tidb") {
+		flavor.Vendor = VendorMySQL
+		flavor.Variants = VariantTiDB
 	} else {
 		for _, attempt := range []Vendor{VendorMariaDB, VendorMySQL} {
 			if vs := attempt.String(); strings.Contains(versionComment, vs) || strings.Contains(versionString, vs) {


### PR DESCRIPTION
This is to deal with difference in collation for some system tables.

See also: 
- #219 
- https://github.com/pingcap/tidb/issues/46288
- https://github.com/pingcap/tidb/issues/46318

TiDB is implementing the MySQL Protocol and syntax of MySQL. While it is not sharing the same code base as MySQL, the syntax etc is closer to MySQL than a fork of MySQL. That's why this has TiDB as a Variant of MySQL and not as a completely separate vendor.

To test with TiDB:
- Run `tiup playground` (see https://tiup.io for  more details)
- Checkout https://github.com/pingcap/tidb and run `make server && ./bin/tidb-server`
- Create a free serverless tier account on https://tidbcloud.com
- The first two will create a local instance on port 4000 that can be accessed as root with no password.

There is more information about the MySQL compatibility of TiDB on  https://docs.pingcap.com/tidb/stable/mysql-compatibility 

I'm aware of some other issues that aren't yet fixed in this PR: In TiDB an ALTER statement with multiple operations can't have multiple operations that refer to the same column. For example `ALTER TABLE t1 ADD COLUMN c1 INT, ADD KEY idx_c1 (c1)` won't work.  While this makes it slightly more difficult to use Skeema with TiDB this normally doesn't cause much issues as the `ADD COLUMN` is a metadata only operation, which makes it very fast and then the `ADD INDEX` is done later and requires building of the index structure. 
